### PR TITLE
Refactor default backend handling and add better events

### DIFF
--- a/controllers/gce/Makefile
+++ b/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.8.0
+TAG = 0.8.1
 PREFIX = gcr.io/google_containers/glbc
 
 server:

--- a/controllers/gce/README.md
+++ b/controllers/gce/README.md
@@ -327,7 +327,7 @@ So simply delete the replication controller:
 $ kubectl get rc glbc
 CONTROLLER   CONTAINER(S)           IMAGE(S)                                      SELECTOR                    REPLICAS   AGE
 glbc         default-http-backend   gcr.io/google_containers/defaultbackend:1.0   k8s-app=glbc,version=v0.5   1          2m
-             l7-lb-controller       gcr.io/google_containers/glbc:0.8.0
+             l7-lb-controller       gcr.io/google_containers/glbc:0.8.1
 
 $ kubectl delete rc glbc
 replicationcontroller "glbc" deleted

--- a/controllers/gce/instances/instances.go
+++ b/controllers/gce/instances/instances.go
@@ -101,9 +101,12 @@ func (i *Instances) DeleteInstanceGroup(name string) error {
 		return err
 	}
 	for _, zone := range zones {
-		glog.Infof("Deleting instance group %v in zone %v", name, zone)
 		if err := i.cloud.DeleteInstanceGroup(name, zone); err != nil {
-			errs = append(errs, err)
+			if !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
+				errs = append(errs, err)
+			}
+		} else {
+			glog.Infof("Deleted instance group %v in zone %v", name, zone)
 		}
 	}
 	if len(errs) == 0 {

--- a/controllers/gce/loadbalancers/loadbalancers.go
+++ b/controllers/gce/loadbalancers/loadbalancers.go
@@ -694,7 +694,7 @@ func (l *L7) UpdateUrlMap(ingressRules utils.GCEURLMap) error {
 	} else {
 		l.um.DefaultService = l.glbcDefaultBackend.SelfLink
 	}
-	glog.V(3).Infof("Updating url map %+v", ingressRules)
+	glog.Infof("Updating url map:\n%+v", ingressRules)
 
 	// Every update replaces the entire urlmap.
 	// TODO:  when we have multiple loadbalancers point to a single gce url map

--- a/controllers/gce/main.go
+++ b/controllers/gce/main.go
@@ -61,7 +61,7 @@ const (
 	alphaNumericChar = "0"
 
 	// Current docker image version. Only used in debug logging.
-	imageVersion = "glbc:0.8.0"
+	imageVersion = "glbc:0.8.1"
 
 	// Key used to persist UIDs to configmaps.
 	uidConfigMapName = "ingress-uid"

--- a/controllers/gce/rc.yaml
+++ b/controllers/gce/rc.yaml
@@ -24,18 +24,18 @@ metadata:
   name: l7-lb-controller
   labels:
     k8s-app: glbc
-    version: v0.6.2
+    version: v0.8.1
 spec:
   # There should never be more than 1 controller alive simultaneously.
   replicas: 1
   selector:
     k8s-app: glbc
-    version: v0.6.2
+    version: v0.8.1
   template:
     metadata:
       labels:
         k8s-app: glbc
-        version: v0.6.2
+        version: v0.8.1
         name: glbc
     spec:
       terminationGracePeriodSeconds: 600
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.8.0
+      - image: gcr.io/google_containers/glbc:0.8.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/gce/storage/pools.go
+++ b/controllers/gce/storage/pools.go
@@ -103,7 +103,7 @@ func (c *CloudListingPool) ReplenishPool() {
 	for i := range items {
 		key, err := c.keyGetter(items[i])
 		if err != nil {
-			glog.V(4).Infof("CloudListingPool: %v", err)
+			glog.V(5).Infof("CloudListingPool: %v", err)
 			continue
 		}
 		c.InMemoryPool.Add(key, items[i])

--- a/controllers/gce/utils/utils.go
+++ b/controllers/gce/utils/utils.go
@@ -79,6 +79,15 @@ const (
 	// K8sAnnotationPrefix is the prefix used in annotations used to record
 	// debug information in the Ingress annotations.
 	K8sAnnotationPrefix = "ingress.kubernetes.io"
+
+	// DefaultHealthCheckInterval defines how frequently a probe runs
+	DefaultHealthCheckInterval = 60
+	// DefaultHealthyThreshold defines the threshold of success probes that declare a backend "healthy"
+	DefaultHealthyThreshold = 1
+	// DefaultUnhealthyThreshold defines the threshold of failure probes that declare a backend "unhealthy"
+	DefaultUnhealthyThreshold = 10
+	// DefaultTimeoutSeconds defines the timeout of each probe
+	DefaultTimeoutSeconds = 60
 )
 
 // Namer handles centralized naming for the cluster.
@@ -305,12 +314,12 @@ func DefaultHealthCheckTemplate(port int64) *compute.HttpHealthCheck {
 		RequestPath: "",
 		Description: "Default kubernetes L7 Loadbalancing health check.",
 		// How often to health check.
-		CheckIntervalSec: 1,
+		CheckIntervalSec: DefaultHealthCheckInterval,
 		// How long to wait before claiming failure of a health check.
-		TimeoutSec: 1,
+		TimeoutSec: DefaultTimeoutSeconds,
 		// Number of healthchecks to pass for a vm to be deemed healthy.
-		HealthyThreshold: 1,
+		HealthyThreshold: DefaultHealthyThreshold,
 		// Number of healthchecks to fail before the vm is deemed unhealthy.
-		UnhealthyThreshold: 10,
+		UnhealthyThreshold: DefaultUnhealthyThreshold,
 	}
 }


### PR DESCRIPTION
We were setting up and tearing down the default http backend used in url maps that don't have a user specified default backend in weird places that didn't make sense. This pr also sends better events that include health check information, and sets better timeouts on readiness-probes converted to health checks. 