### PR TITLE
fix typo in variable ProxyRealIPCIDR

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -14,7 +14,7 @@ events {
 http {
     {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
     {{ if $cfg.UseProxyProtocol }}
-    set_real_ip_from    {{ $cfg.ProxyRealIpCidr }};
+    set_real_ip_from    {{ $cfg.ProxyRealIPCIDR }};
     real_ip_header      proxy_protocol;
     {{ else }}
     real_ip_header      X-Forwarded-For;


### PR DESCRIPTION
I was running the default template for the ingress controller. I realised a typo in configuration, only renaming the var solve the issue.

## Args
```
# ./nginx-ingress-controller 
--default-backend-service=kube-system/default-http-backend 
--tcp-services-configmap=kube-system/tcp-configmap 
--configmap=kube-system/nginx-load-balancer-conf
```

## Error
```
...
W1212 13:18:13.925417      19 controller.go:833] service */* does not have any active endpoints
W1212 13:18:14.006342      19 queue.go:82] requeuing gitlab/kubedash, err template: nginx.tmpl:17:31: executing "nginx.tmpl" at <$cfg.ProxyRealIpCidr>: can't evaluate field **ProxyRealIpCidr** 
in type config.Configuration
```