### PR TITLE
Fix "invalid port in upstream" on nginx controller

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/metrics.go
+++ b/controllers/nginx/pkg/cmd/controller/metrics.go
@@ -42,7 +42,7 @@ func (em exeMatcher) MatchAndName(nacl common.NameAndCmdline) (bool, string) {
 func (n *NGINXController) setupMonitor(args []string) {
 	pc, err := newProcessCollector(true, exeMatcher{"nginx", args})
 	if err != nil {
-		glog.Fatalf("unexpedted error registering nginx collector: %v", err)
+		glog.Fatalf("unexpected error registering nginx collector: %v", err)
 	}
 	err = prometheus.Register(pc)
 	if err != nil {

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -982,7 +982,7 @@ func (ic *GenericController) getEndpoints(
 			}
 
 			// check for invalid port value
-			if targetPort == -1 {
+			if targetPort <=0 {
 				continue
 			}
 


### PR DESCRIPTION
If you don't have the ingress port mapped same as the service, you got the error "invalid port in upstream" on nginx. To fix this, we should check if the targetPort is valid (>0).
Fix #53