### PR TITLE
Do not push containers to remote repo as part of test-e2e.

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -214,7 +214,7 @@ func run(deploy deployer) error {
 func Build() error {
 	// The build-release script needs stdin to ask the user whether
 	// it's OK to download the docker image.
-	cmd := exec.Command("make", "docker-build", "docker-push")
+	cmd := exec.Command("make", "docker-build")
 	cmd.Stdin = os.Stdin
 	if err := finishRunning("build-release", cmd); err != nil {
 		return fmt.Errorf("error building: %v", err)


### PR DESCRIPTION
Since the cluster runs locally, this seems unnecessary.
Fixes #79.