### PR TITLE
Update X-Forwarded-Port

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -107,6 +107,11 @@ http {
         default          $http_x_forwarded_proto;
         ''               $scheme;
     }
+    
+    map $http_x_forwarded_proto $pass_server_port {
+      default $http_x_forwarded_port;
+      ''      $server_port;
+    }
 
     # Map a response error watching the header Content-Type
     map $http_accept $httpAccept {
@@ -197,7 +202,7 @@ http {
         {{ end }}
 
         # map port 442 to 443 for header X-Forwarded-Port
-        map $pass_port $server_port {
+        map $pass_port $pass_server_port {
             442                                 443;
             default                             80;
         }

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -108,7 +108,7 @@ http {
         ''               $scheme;
     }
     
-    map $http_x_forwarded_proto $pass_server_port {
+    map $http_x_forwarded_port $pass_server_port {
       default $http_x_forwarded_port;
       ''      $server_port;
     }


### PR DESCRIPTION
It appears this package is assuming the port running on the Ingress Controller as the port.

In the current situation, if my LB sends X-Forwarded-Port: 443 and the ingress controller is running on port 80. X-Forwarded-Port: 80 will end up in my app.

Now it's correctly routing.