### PR TITLE
Fix multiple tls hosts sharing the same secretName

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -902,8 +902,18 @@ func (ic *GenericController) createServers(data []interface{}, upstreams map[str
 
 			// only add a certificate if the server does not have one previously configured
 			// TODO: TLS without secret?
-			if len(ing.Spec.TLS) > 0 && servers[host].SSLCertificate == "" && ing.Spec.TLS[0].SecretName != "" {
-				key := fmt.Sprintf("%v/%v", ing.Namespace, ing.Spec.TLS[0].SecretName)
+			if len(ing.Spec.TLS) > 0 && servers[host].SSLCertificate == "" {
+				tlsSecretName := ""
+				for _, tls := range ing.Spec.TLS {
+					for _, tlsHost := range tls.Hosts {
+						if tlsHost == host {
+							tlsSecretName = tls.SecretName
+							break
+						}
+					}
+				}
+
+				key := fmt.Sprintf("%v/%v", ing.Namespace, tlsSecretName)
 				bc, exists := ic.sslCertTracker.Get(key)
 				if exists {
 					cert := bc.(*ingress.SSLCert)


### PR DESCRIPTION
The new controller changed the way that lookup for a ssl certificate. On the current ingress, on contrib, this tls mapping below works, but when I moved for this repo, some tls aren't generated.   

```
    tls:
    - hosts:
      - aaaa.fake-domain.me
      secretName: auth.fake-domain.me
    - hosts:
      - nnnn.fake-domain.me
      secretName: cauth.fake-domain.me
    - hosts:
      - gggg.fake-domain.me
      secretName: gate.fake-domain.me
    - hosts:
      - my.fake-domain.me
      secretName: my.fake-domain.me
    - hosts:
      - rrrr.fake-domain.me
      - ppp.fake-domain.me
      - jjjj.fake-domain.me
      secretName: eu-fake-domain.me
```