### PR TITLE
Fix x-forwarded-port mapping

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -108,6 +108,17 @@ http {
         ''               $scheme;
     }
 
+    map $http_x_forwarded_port $pass_server_port {
+       default           $http_x_forwarded_port;
+       ''                $server_port;
+    }
+
+    # map port 442 to 443 for header X-Forwarded-Port
+    map $pass_server_port $pass_port {
+        442              443;
+        default          $pass_server_port;
+    }
+
     # Map a response error watching the header Content-Type
     map $http_accept $httpAccept {
         default          html;
@@ -195,12 +206,6 @@ http {
         ssl_certificate                         {{ $server.SSLCertificate }};
         ssl_certificate_key                     {{ $server.SSLCertificate }};
         {{ end }}
-
-        # map port 442 to 443 for header X-Forwarded-Port
-        map $pass_port $server_port {
-            442                                 443;
-            default                             80;
-        }
 
         {{ if (and (not (empty $server.SSLCertificate)) $cfg.HSTS) }}
         more_set_headers                        "Strict-Transport-Security: max-age={{ $cfg.HSTSMaxAge }}{{ if $cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }}; preload";


### PR DESCRIPTION
replaces #86

```
$ curl  localhost -H 'Host: foo-98.bar.com'
CLIENT VALUES:
client_address=10.2.9.2
command=GET
real path=/
query=nil
request_version=1.1
request_uri=http://foo-98.bar.com:8080/

SERVER VALUES:
server_version=nginx: 1.9.11 - lua: 10001

HEADERS RECEIVED:
accept=*/*
connection=close
host=foo-98.bar.com
user-agent=curl/7.50.2
x-forwarded-for=::ffff:10.2.9.1
x-forwarded-host=foo-98.bar.com
x-forwarded-port=80
x-forwarded-proto=http
x-real-ip=::ffff:10.2.9.1
BODY:
-no body in request-

$ curl  localhost -H 'Host: foo-98.bar.com' -H 'x-forwarded-port: 81'
CLIENT VALUES:
client_address=10.2.9.2
command=GET
real path=/
query=nil
request_version=1.1
request_uri=http://foo-98.bar.com:8080/

SERVER VALUES:
server_version=nginx: 1.9.11 - lua: 10001

HEADERS RECEIVED:
accept=*/*
connection=close
host=foo-98.bar.com
user-agent=curl/7.50.2
x-forwarded-for=::ffff:10.2.9.1
x-forwarded-host=foo-98.bar.com
x-forwarded-port=81
x-forwarded-proto=http
x-real-ip=::ffff:10.2.9.1
BODY:
-no body in request-

$ curl  localhost -H 'Host: foo-98.bar.com' -H 'x-forwarded-port: 442'
CLIENT VALUES:
client_address=10.2.9.2
command=GET
real path=/
query=nil
request_version=1.1
request_uri=http://foo-98.bar.com:8080/

SERVER VALUES:
server_version=nginx: 1.9.11 - lua: 10001

HEADERS RECEIVED:
accept=*/*
connection=close
host=foo-98.bar.com
user-agent=curl/7.50.2
x-forwarded-for=::ffff:10.2.9.1
x-forwarded-host=foo-98.bar.com
x-forwarded-port=443
x-forwarded-proto=http
x-real-ip=::ffff:10.2.9.1
BODY:
-no body in request-

$ curl  localhost -H 'Host: foo-98.bar.com' -H 'x-forwarded-port: 9000'
CLIENT VALUES:
client_address=10.2.9.2
command=GET
real path=/
query=nil
request_version=1.1
request_uri=http://foo-98.bar.com:8080/

SERVER VALUES:
server_version=nginx: 1.9.11 - lua: 10001

HEADERS RECEIVED:
accept=*/*
connection=close
host=foo-98.bar.com
user-agent=curl/7.50.2
x-forwarded-for=::ffff:10.2.9.1
x-forwarded-host=foo-98.bar.com
x-forwarded-port=9000
x-forwarded-proto=http
x-real-ip=::ffff:10.2.9.1
BODY:
-no body in request-
```