### PR TITLE
GCE: dont sync broken lbs

### DIFF
--- a/controllers/gce/controller/controller.go
+++ b/controllers/gce/controller/controller.go
@@ -290,11 +290,11 @@ func (lbc *LoadBalancerController) sync(key string) (err error) {
 	}
 	glog.V(3).Infof("Syncing %v", key)
 
-	paths, err := lbc.ingLister.List()
+	ingresses, err := lbc.ingLister.List()
 	if err != nil {
 		return err
 	}
-	nodePorts := lbc.tr.toNodePorts(&paths)
+	nodePorts := lbc.tr.toNodePorts(&ingresses)
 	lbNames := lbc.ingLister.Store.ListKeys()
 	lbs, err := lbc.ListRuntimeInfo()
 	if err != nil {
@@ -320,8 +320,13 @@ func (lbc *LoadBalancerController) sync(key string) (err error) {
 	//   successful GC we know that there are no dangling cloud resources that
 	//   don't have an associated Kubernetes Ingress/Service/Endpoint.
 
+	allNodePorts := []int64{}
+	for _, lb := range lbs {
+		allNodePorts = append(allNodePorts, lb.NodePorts...)
+	}
+	lbNames := lbc.ingLister.Store.ListKeys()
 	defer func() {
-		if deferErr := lbc.CloudClusterManager.GC(lbNames, nodePorts); deferErr != nil {
+		if deferErr := lbc.CloudClusterManager.GC(lbNames, allNodePorts); deferErr != nil {
 			err = fmt.Errorf("Error during sync %v, error during GC %v", err, deferErr)
 		}
 		glog.V(3).Infof("Finished syncing %v", key)
@@ -330,7 +335,7 @@ func (lbc *LoadBalancerController) sync(key string) (err error) {
 	// Record any errors during sync and throw a single error at the end. This
 	// allows us to free up associated cloud resources ASAP.
 	var syncError error
-	if err := lbc.CloudClusterManager.Checkpoint(lbs, nodeNames, nodePorts); err != nil {
+	if err := lbc.CloudClusterManager.Checkpoint(lbs, nodeNames, allNodePorts); err != nil {
 		// TODO: Implement proper backoff for the queue.
 		eventMsg := "GCE"
 		if utils.IsHTTPErrorCode(err, http.StatusForbidden) {
@@ -427,15 +432,54 @@ func (lbc *LoadBalancerController) ListRuntimeInfo() (lbs []*loadbalancers.L7Run
 		if err != nil {
 			glog.Warningf("Cannot get certs for Ingress %v/%v: %v", ing.Namespace, ing.Name, err)
 		}
+		nodePorts, missingPorts := lbc.getNodePorts(&ing)
+		if len(missingPorts) > 0 {
+			glog.Warningf("Ingress %v/%v is missing some NodePorts", ing.Namespace, ing.Name)
+		}
+
 		annotations := ingAnnotations(ing.ObjectMeta.Annotations)
 		lbs = append(lbs, &loadbalancers.L7RuntimeInfo{
 			Name:         k,
 			TLS:          tls,
+			NodePorts:    nodePorts,
 			AllowHTTP:    annotations.allowHTTP(),
 			StaticIPName: annotations.staticIPName(),
 		})
 	}
 	return lbs, nil
+}
+
+func (lbc *LoadBalancerController) getNodePorts(ing *extensions.Ingress) ([]int64, []int64) {
+	nodePorts := []int64{}
+	missing := []int64{}
+
+	defaultBackend := ing.Spec.Backend
+	if defaultBackend != nil {
+		port, err := lbc.tr.getServiceNodePort(*defaultBackend, ing.Namespace)
+		if err != nil {
+			lbc.recorder.Eventf(ing, api.EventTypeWarning, "Service", err.Error())
+			missing = append(missing, int64(port))
+		} else {
+			nodePorts = append(nodePorts, int64(port))
+		}
+	}
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			glog.Errorf("Ignoring non http Ingress rule.")
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			port, err := lbc.tr.getServiceNodePort(path.Backend, ing.Namespace)
+			if err != nil {
+				lbc.recorder.Eventf(ing, api.EventTypeWarning, "Service", err.Error())
+				missing = append(missing, int64(port))
+				continue
+			}
+			nodePorts = append(nodePorts, int64(port))
+		}
+	}
+
+	return nodePorts, missing
 }
 
 // syncNodes manages the syncing of kubernetes nodes to gce instance groups.

--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -331,37 +331,6 @@ func (t *GCETranslator) getServiceNodePort(be extensions.IngressBackend, namespa
 		"Could not find matching nodeport from service.")}
 }
 
-// toNodePorts converts a pathlist to a flat list of nodeports.
-func (t *GCETranslator) toNodePorts(ings *extensions.IngressList) []int64 {
-	knownPorts := []int64{}
-	for _, ing := range ings.Items {
-		defaultBackend := ing.Spec.Backend
-		if defaultBackend != nil {
-			port, err := t.getServiceNodePort(*defaultBackend, ing.Namespace)
-			if err != nil {
-				glog.Infof("%v", err)
-			} else {
-				knownPorts = append(knownPorts, int64(port))
-			}
-		}
-		for _, rule := range ing.Spec.Rules {
-			if rule.HTTP == nil {
-				glog.Errorf("Ignoring non http Ingress rule.")
-				continue
-			}
-			for _, path := range rule.HTTP.Paths {
-				port, err := t.getServiceNodePort(path.Backend, ing.Namespace)
-				if err != nil {
-					glog.Infof("%v", err)
-					continue
-				}
-				knownPorts = append(knownPorts, int64(port))
-			}
-		}
-	}
-	return knownPorts
-}
-
 func getZone(n *api.Node) string {
 	zone, ok := n.Labels[zoneKey]
 	if !ok {


### PR DESCRIPTION
@bprashanth before tests and stuff like that, PTAL.  This will stop hot-looping on GCE when a service is broken.