### PR TITLE
annotations: print error and skip if malformed

### DIFF
--- a/core/pkg/ingress/annotations/rewrite/main.go
+++ b/core/pkg/ingress/annotations/rewrite/main.go
@@ -17,8 +17,6 @@ limitations under the License.
 package rewrite
 
 import (
-	"errors"
-
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
 	"k8s.io/ingress/core/pkg/ingress/annotations/parser"
@@ -46,7 +44,7 @@ type Redirect struct {
 // rule used to rewrite the defined paths
 func ParseAnnotations(cfg defaults.Backend, ing *extensions.Ingress) (*Redirect, error) {
 	if ing.GetAnnotations() == nil {
-		return &Redirect{}, errors.New("no annotations present")
+		return &Redirect{}, parser.ErrMissingAnnotations
 	}
 
 	sslRe, err := parser.GetBoolAnnotation(sslRedirect, ing)


### PR DESCRIPTION
Logging annotation errors at v5 effectively means that errors are
silent.

In addition, continuing to setup an ingress rule *after* a malformed
authentication, rate limit, or whitelist annotation was noticed seems
a bit bad.
If a user typoes the value of an annotation, they don't deserve to be
left in a horribly insecure state, merely in a broken one.