### PR TITLE
FIX: ingress was not creating the endpoint when target port is string

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -975,7 +975,7 @@ func (ic *GenericController) getEndpoints(
 				port, err := service.GetPortMapping(servicePort.StrVal, s)
 				if err == nil {
 					targetPort = port
-					continue
+					break
 				}
 
 				glog.Warningf("error mapping service port: %v", err)


### PR DESCRIPTION
When using target port as string, nginx can't generate the right upstream. 

```
$kubectl get svc prometheus-k8s -o yaml
apiVersion: v1
kind: Service
metadata:  
  name: prometheus-k8s
  namespace: kube-system
spec:
  clusterIP:  ***
  ports:
  - name: web
    nodePort: 3900
    port: 9090
    protocol: TCP
    targetPort: web
  selector:
    prometheus: prometheus-k8s
  sessionAffinity: None
  type: NodePort
status:
  loadBalancer: {}
```

Output when using targetPort: web
```
[temp-nginx-ingress-controller-vki2s] W0110 10:40:36.638062       7 controller.go:833] service kube-system/prometheus-k8s does not have any active endpoints
```

diff nginx.conf after patching
```
grubio@localhost:~$ diff nginx.conf-old nginx.conf-new
359c359
<         server 127.0.0.1:8181 max_fails=0 fail_timeout=0;
---
>         server 10.5.2.16:9090 max_fails=0 fail_timeout=0;
```

Fixed