### PR TITLE
Add resolver configuration to nginx

### DIFF
--- a/controllers/nginx/pkg/template/configmap.go
+++ b/controllers/nginx/pkg/template/configmap.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 
 	"k8s.io/ingress/controllers/nginx/pkg/config"
+	"k8s.io/ingress/core/pkg/net/dns"
 )
 
 const (
@@ -68,6 +69,13 @@ func ReadConfig(conf *api.ConfigMap) config.Configuration {
 	to.CustomHTTPErrors = filterErrors(errors)
 	to.SkipAccessLogURLs = skipUrls
 	to.WhitelistSourceRange = whitelist
+
+	h, err := dns.GetSystemNameServers()
+	if err != nil {
+		glog.Warningf("unexpected error reading system nameservers: %v", err)
+	} else {
+		to.Resolver = h
+	}
 
 	config := &mapstructure.DecoderConfig{
 		Metadata:         nil,

--- a/controllers/nginx/pkg/template/configmap_test.go
+++ b/controllers/nginx/pkg/template/configmap_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/ingress/controllers/nginx/pkg/config"
+	"k8s.io/ingress/core/pkg/net/dns"
 	"k8s.io/kubernetes/pkg/api"
 )
 
@@ -52,6 +53,12 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.EnableDynamicTLSRecords = false
 	def.UseProxyProtocol = true
 	def.GzipTypes = "text/html"
+
+	h, err := dns.GetSystemNameServers()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	def.Resolver = h
 
 	to := ReadConfig(conf)
 	if !reflect.DeepEqual(def, to) {


### PR DESCRIPTION
The nginx revolver configuration is needed when the external authentication annotation is used.