### PR TITLE
Only delete default backend when there are no loadbalancers

### DIFF
--- a/controllers/gce/backends/backends.go
+++ b/controllers/gce/backends/backends.go
@@ -273,12 +273,6 @@ func (b *Backends) GC(svcNodePorts []int64) error {
 			return err
 		}
 	}
-	if len(svcNodePorts) == 0 {
-		glog.Infof("Deleting instance group %v", b.namer.IGName())
-		if err := b.nodePool.DeleteInstanceGroup(b.namer.IGName()); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
Previously we were deleting the IG(s) when there were no more backend services (i.e the backend pool had no Services to sync). This mirrors how they are created. 

However, in the case where we have an Ingress with 0 nodeports (i.e user sticks type=ClusterIP Services into the Ingress), we would still like the lb to get an IP, and requests sent to this IP to get a 404 from the default backend.  For this we need to keep the default backend around till there are no more lbs, and by extension, we also need to keep the IG around for the default backend. 

Also adds some better events in the case where the default backend has no nodeport. 