### PR TITLE
change the type of imagePullPolicy

### DIFF
--- a/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
@@ -73,7 +73,6 @@ spec:
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-controller
-        imagePullPolicy: Always
         readinessProbe:
           httpGet:
             path: /healthz

--- a/examples/deployment/nginx/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/nginx-ingress-controller.yaml
@@ -21,7 +21,6 @@ spec:
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-controller
-        imagePullPolicy: Always
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
 I thought "IfNotPresent" should be better than "Always". 
Reasons: All the images("gcr.io/google_containers/nginx-ingress-controller") which exist have a fixed tag(not :latest). The tag will be changed if this image change to a new version. So, IMO, no matter how many times, the download image is the same one, and we don't need download it again when it exists.
thank you!