### PR TITLE
Add reuse port and backlog to port 80 and 443

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -194,10 +194,11 @@ http {
     {{ $zone }}
     {{ end }}
 
+    {{ $backlogSize := .BacklogSize }}
     {{ range $index, $server := .Servers }}
     server {
         server_name {{ $server.Hostname }};
-        listen [::]:80{{ if $cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $index 0 }} ipv6only=off{{end}}{{ if eq $server.Hostname "_"}} default_server{{end}};
+        listen [::]:80{{ if $cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $index 0 }} ipv6only=off{{end}}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $backlogSize }}{{end}};
         {{/* Listen on 442 because port 443 is used in the stream section */}}
         {{ if not (empty $server.SSLCertificate) }}listen 442 {{ if $cfg.UseProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.UseHTTP2 }}http2{{ end }};
         {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}


### PR DESCRIPTION
https://nginx.org/en/docs/stream/ngx_stream_core_module.html#listen

`reuseport` and `backlog` are already present in the config but only for port 18080