### PR TITLE
Fix rate limit issue when more than 2 servers enabled in ingress

### DIFF
--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	text_template "text/template"
 
+	"k8s.io/kubernetes/pkg/util/sets"
+
 	"github.com/golang/glog"
 
 	"k8s.io/ingress/controllers/nginx/pkg/config"
@@ -328,11 +330,11 @@ func buildProxyPass(b interface{}, loc interface{}) string {
 // rate limiting of request. Each Ingress rule could have up to two zones, one
 // for connection limit by IP address and other for limiting request per second
 func buildRateLimitZones(input interface{}) []string {
-	zones := []string{}
+	zones := sets.String{}
 
 	servers, ok := input.([]*ingress.Server)
 	if !ok {
-		return zones
+		return zones.List()
 	}
 
 	for _, server := range servers {
@@ -342,7 +344,9 @@ func buildRateLimitZones(input interface{}) []string {
 				zone := fmt.Sprintf("limit_conn_zone $binary_remote_addr zone=%v:%vm;",
 					loc.RateLimit.Connections.Name,
 					loc.RateLimit.Connections.SharedSize)
-				zones = append(zones, zone)
+				if !zones.Has(zone) {
+					zones.Insert(zone)
+				}
 			}
 
 			if loc.RateLimit.RPS.Limit > 0 {
@@ -350,12 +354,14 @@ func buildRateLimitZones(input interface{}) []string {
 					loc.RateLimit.RPS.Name,
 					loc.RateLimit.RPS.SharedSize,
 					loc.RateLimit.RPS.Limit)
-				zones = append(zones, zone)
+				if !zones.Has(zone) {
+					zones.Insert(zone)
+				}
 			}
 		}
 	}
 
-	return zones
+	return zones.List()
 }
 
 // buildRateLimit produces an array of limit_req to be used inside the Path of


### PR DESCRIPTION
When more than 2 servers enabled in ingress with rate limit enabled, nginx config file check will output error message like this:
[emerg] limit_conn_zone "default_echomap_conn" is already bound to key "$binary_remote_addr"

Signed-off-by: Tang Le <at28997146@163.com>