### PR TITLE
Fix redirects of backends with port other than 80

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -214,6 +214,10 @@ http {
         more_set_headers                        "Strict-Transport-Security: max-age={{ $cfg.HSTSMaxAge }}{{ if $cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }}; preload";
         {{ end }}
 
+        {{ if not (eq $server.Hostname "_") }}
+        proxy_redirect ~https?://{{ $server.Hostname }}:?[0-9]*/(.*) /$1;
+        {{ end }}
+
         {{ if $cfg.EnableVtsStatus }}vhost_traffic_status_filter_by_set_key $geoip_country_code country::$server_name;{{ end }}
 
         {{ range $location := $server.Locations }}
@@ -308,7 +312,6 @@ http {
             proxy_send_timeout                      {{ $location.Proxy.SendTimeout }}s;
             proxy_read_timeout                      {{ $location.Proxy.ReadTimeout }}s;
 
-            proxy_redirect                          off;
             proxy_buffering                         off;
             proxy_buffer_size                       "{{ $location.Proxy.BufferSize }}";
 


### PR DESCRIPTION
Out deployment has the following use case:

* Ingress references a backend on port `:8080`
* Backend normalize URLs redirecting `/some/folder` to `/some/folder/`

The problem here is that the backend redirect to `:8080` but the ingress controller doesn't change the `Location:` header to `:80`, which is the port the ingress controller is listening.

What I have observed so far is that, when using `proxy_pass` with an upstream, the `$proxy_port` variable on nginx is `80` regardless of the port being used on upstream and backends.

The following change fixes this problem but assume the port of the ingress controller is always 80 over http and 443 over https.