### PR TITLE
Changes the SSL Temp Dir

### DIFF
--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -133,7 +133,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 
 	os.MkdirAll(ingress.DefaultSSLDirectory, 0655)
 	// Creates a temp directory for Certificates, as 'rename' functions need to be in the same mount point as the Certificates
-	os.MkdirAll(ingress.TempSSLDirectory,0655)
+	os.MkdirAll(ingress.TempSSLDirectory, 0655)
 
 	config := &Configuration{
 		UpdateStatus:          *updateStatus,

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -132,6 +132,8 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 	}
 
 	os.MkdirAll(ingress.DefaultSSLDirectory, 0655)
+	// Creates a temp directory for Certificates, as 'rename' functions need to be in the same mount point as the Certificates
+	os.MkdirAll(ingress.TempSSLDirectory,0655)
 
 	config := &Configuration{
 		UpdateStatus:          *updateStatus,

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -36,6 +36,7 @@ var (
 	// The name of each file is <namespace>-<secret name>.pem. The content is the concatenated
 	// certificate and key.
 	DefaultSSLDirectory = "/ingress-controller/ssl"
+	TempSSLDirectory = "/ingress-controller/ssl/temp"
 )
 
 // Controller holds the methods to handle an Ingress backend

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -36,7 +36,7 @@ var (
 	// The name of each file is <namespace>-<secret name>.pem. The content is the concatenated
 	// certificate and key.
 	DefaultSSLDirectory = "/ingress-controller/ssl"
-	TempSSLDirectory = "/ingress-controller/ssl/temp"
+	TempSSLDirectory    = "/ingress-controller/ssl/temp"
 )
 
 // Controller holds the methods to handle an Ingress backend

--- a/core/pkg/net/ssl/ssl.go
+++ b/core/pkg/net/ssl/ssl.go
@@ -36,7 +36,7 @@ func AddOrUpdateCertAndKey(name string, cert, key, ca []byte) (*ingress.SSLCert,
 	pemName := fmt.Sprintf("%v.pem", name)
 	pemFileName := fmt.Sprintf("%v/%v", ingress.DefaultSSLDirectory, pemName)
 
-	tempPemFile, err := ioutil.TempFile("", pemName)
+	tempPemFile, err := ioutil.TempFile(ingress.TempSSLDirectory, pemName)
 	if err != nil {
 		return nil, fmt.Errorf("could not create temp pem file %v: %v", tempPemFile.Name(), err)
 	}


### PR DESCRIPTION
This PR makes the following code changes:

When configuring SSL Certificate, instead of creating a new file on the 'OS Temp' directory, creates the temp directory (and files) in the same SSL Certificates directory.

This is necessary when running ingress controller in bare metal. Having a different mount point to '/tmp' causes the ingress controller to hang, when trying to move/rename the file to the parsed one.

This is related to this PR: https://github.com/kubernetes/contrib/pull/2242