### PR TITLE
Corrects the behaviour of default-ssl-certificate

### DIFF
--- a/controllers/gce/README.md
+++ b/controllers/gce/README.md
@@ -51,7 +51,7 @@ __Lines 5-7__: Ingress Spec has all the information needed to configure a GCE L7
 
 __Lines 8-9__: Each http rule contains the following information: A host (eg: foo.bar.com, defaults to `*` in this example), a list of paths (eg: `/hostless`) each of which has an associated backend (`test:80`). Both the `host` and `path` must match the content of an incoming request before the L7 directs traffic to the `backend`.
 
-__Lines 10-12__: A `backend` is a service:port combination. It selects a group of pods capable of servicing traffic sent to the path specified in the parent rule.
+__Lines 10-12__: A `backend` is a service:port combination. It selects a group of pods capable of servicing traffic sent to the path specified in the parent rule. The `port` is the desired `spec.ports[*].port` from the Service Spec -- Note, though, that the L7 actually directs traffic to the corresponding `NodePort`.
 
 __Global Prameters__: For the sake of simplicity the example Ingress has no global parameters. However, one can specify a default backend (see examples below) in the absence of which requests that don't match a path in the spec are sent to the default backend of glbc. Though glbc doesn't support HTTPS yet, security configs would also be global.
 

--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	text_template "text/template"
 
+	"k8s.io/kubernetes/pkg/util/sets"
+
 	"github.com/golang/glog"
 
 	"k8s.io/ingress/controllers/nginx/pkg/config"
@@ -328,11 +330,11 @@ func buildProxyPass(b interface{}, loc interface{}) string {
 // rate limiting of request. Each Ingress rule could have up to two zones, one
 // for connection limit by IP address and other for limiting request per second
 func buildRateLimitZones(input interface{}) []string {
-	zones := []string{}
+	zones := sets.String{}
 
 	servers, ok := input.([]*ingress.Server)
 	if !ok {
-		return zones
+		return zones.List()
 	}
 
 	for _, server := range servers {
@@ -342,7 +344,9 @@ func buildRateLimitZones(input interface{}) []string {
 				zone := fmt.Sprintf("limit_conn_zone $binary_remote_addr zone=%v:%vm;",
 					loc.RateLimit.Connections.Name,
 					loc.RateLimit.Connections.SharedSize)
-				zones = append(zones, zone)
+				if !zones.Has(zone) {
+					zones.Insert(zone)
+				}
 			}
 
 			if loc.RateLimit.RPS.Limit > 0 {
@@ -350,12 +354,14 @@ func buildRateLimitZones(input interface{}) []string {
 					loc.RateLimit.RPS.Name,
 					loc.RateLimit.RPS.SharedSize,
 					loc.RateLimit.RPS.Limit)
-				zones = append(zones, zone)
+				if !zones.Has(zone) {
+					zones.Insert(zone)
+				}
 			}
 		}
 	}
 
-	return zones
+	return zones.List()
 }
 
 // buildRateLimit produces an array of limit_req to be used inside the Path of

--- a/controllers/nginx/rootfs/Dockerfile
+++ b/controllers/nginx/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-slim:0.12
+FROM gcr.io/google_containers/nginx-slim:0.13
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   diffutils \

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -203,7 +203,7 @@ http {
         server_name {{ $server.Hostname }};
         listen [::]:80{{ if $cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $index 0 }} ipv6only=off{{end}}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $backlogSize }}{{end}};
         {{/* Listen on 442 because port 443 is used in the stream section */}}
-        {{ if not (empty $server.SSLCertificate) }}listen 442 {{ if $cfg.UseProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.UseHTTP2 }}http2{{ end }};
+        {{ if not (empty $server.SSLCertificate) }}listen 442 {{ if $cfg.UseProxyProtocol }}proxy_protocol{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $backlogSize }}{{end}} ssl {{ if $cfg.UseHTTP2 }}http2{{ end }};
         {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
         # PEM sha: {{ $server.SSLPemChecksum }}
         ssl_certificate                         {{ $server.SSLCertificate }};

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/resolver"
 	"k8s.io/ingress/core/pkg/ingress/status"
 	"k8s.io/ingress/core/pkg/k8s"
+	ssl "k8s.io/ingress/core/pkg/net/ssl"
 	local_strings "k8s.io/ingress/core/pkg/strings"
 	"k8s.io/ingress/core/pkg/task"
 )
@@ -827,9 +828,30 @@ func (ic *GenericController) createServers(data []interface{}, upstreams map[str
 
 	dun := ic.getDefaultUpstream().Name
 
+	// This adds the Default Certificate to Default Backend and also for vhosts missing the secret
+	var defaultPemFileName, defaultPemSHA string
+	defaultCertificate, err := ic.getPemCertificate(ic.cfg.DefaultSSLCertificate)
+	// If no default Certificate was supplied, tries to generate a new dumb one
+	if err != nil {
+		var cert *ingress.SSLCert
+		defCert, defKey := ssl.GetFakeSSLCert()
+		cert, err = ssl.AddOrUpdateCertAndKey("system-snake-oil-certificate", defCert, defKey, []byte{})
+		if err != nil {
+			glog.Fatalf("Error generating self signed certificate: %v", err)
+		} else {
+			defaultPemFileName = cert.PemFileName
+			defaultPemSHA = cert.PemSHA
+		}
+	} else {
+		defaultPemFileName = defaultCertificate.PemFileName
+		defaultPemSHA = defaultCertificate.PemSHA
+	}
+
 	// default server
 	servers[defServerName] = &ingress.Server{
-		Hostname: defServerName,
+		Hostname:       defServerName,
+		SSLCertificate: defaultPemFileName,
+		SSLPemChecksum: defaultPemSHA,
 		Locations: []*ingress.Location{
 			{
 				Path:         rootLocation,
@@ -899,7 +921,8 @@ func (ic *GenericController) createServers(data []interface{}, upstreams map[str
 						servers[host].SSLPemChecksum = cert.PemSHA
 					}
 				} else {
-					glog.Warningf("secret %v does not exists", key)
+					servers[host].SSLCertificate = defaultPemFileName
+					servers[host].SSLPemChecksum = defaultPemSHA
 				}
 			}
 

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -54,14 +54,14 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		tcpConfigMapName = flags.String("tcp-services-configmap", "",
 			`Name of the ConfigMap that contains the definition of the TCP services to expose.
 		The key in the map indicates the external port to be used. The value is the name of the
-		service with the format namespace/serviceName and the port of the service could be a 
+		service with the format namespace/serviceName and the port of the service could be a
 		number of the name of the port.
 		The ports 80 and 443 are not allowed as external ports. This ports are reserved for the backend`)
 
 		udpConfigMapName = flags.String("udp-services-configmap", "",
 			`Name of the ConfigMap that contains the definition of the UDP services to expose.
 		The key in the map indicates the external port to be used. The value is the name of the
-		service with the format namespace/serviceName and the port of the service could be a 
+		service with the format namespace/serviceName and the port of the service could be a
 		number of the name of the port.`)
 
 		resyncPeriod = flags.Duration("sync-period", 60*time.Second,
@@ -74,13 +74,13 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 
 		profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
 
-		defSSLCertificate = flags.String("default-ssl-certificate", "", `Name of the secret 
+		defSSLCertificate = flags.String("default-ssl-certificate", "", `Name of the secret
 		that contains a SSL certificate to be used as default for a HTTPS catch-all server`)
 
-		defHealthzURL = flags.String("health-check-path", "/healthz", `Defines 
+		defHealthzURL = flags.String("health-check-path", "/healthz", `Defines
 		the URL to be used as health check inside in the default server in NGINX.`)
 
-		updateStatus = flags.Bool("update-status", true, `Indicates if the 
+		updateStatus = flags.Bool("update-status", true, `Indicates if the
 		ingress controller should update the Ingress status IP/hostname. Default is true`)
 	)
 

--- a/core/pkg/ingress/controller/util_test.go
+++ b/core/pkg/ingress/controller/util_test.go
@@ -19,9 +19,24 @@ package controller
 import (
 	"testing"
 
+	"k8s.io/ingress/core/pkg/ingress"
+	"k8s.io/ingress/core/pkg/ingress/annotations/auth"
+	"k8s.io/ingress/core/pkg/ingress/annotations/authreq"
+	"k8s.io/ingress/core/pkg/ingress/annotations/ipwhitelist"
+	"k8s.io/ingress/core/pkg/ingress/annotations/proxy"
+	"k8s.io/ingress/core/pkg/ingress/annotations/ratelimit"
+	"k8s.io/ingress/core/pkg/ingress/annotations/rewrite"
+	"k8s.io/ingress/core/pkg/ingress/resolver"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"reflect"
 )
+
+type fakeError struct{}
+
+func (fe *fakeError) Error() string {
+	return "fakeError"
+}
 
 func TestIsValidClass(t *testing.T) {
 	ing := &extensions.Ingress{
@@ -46,5 +61,101 @@ func TestIsValidClass(t *testing.T) {
 	b = IsValidClass(ing, "nginx")
 	if b {
 		t.Errorf("Expected invalid class but %v returned", b)
+	}
+}
+
+func TestIsHostValid(t *testing.T) {
+	fkCert := &ingress.SSLCert{
+		CAFileName:  "foo",
+		PemFileName: "foo.cr",
+		PemSHA:      "perha",
+		CN: []string{
+			"*.cluster.local", "default.local",
+		},
+	}
+
+	fooTests := []struct {
+		cr   *ingress.SSLCert
+		host string
+		er   bool
+	}{
+		{nil, "foo1.cluster.local", false},
+		{fkCert, "foo1.cluster.local", true},
+		{fkCert, "default.local", true},
+		{fkCert, "foo2.cluster.local.t", false},
+		{fkCert, "", false},
+	}
+
+	for _, foo := range fooTests {
+		r := isHostValid(foo.host, foo.cr)
+		if r != foo.er {
+			t.Errorf("Returned %v but expected %v for foo=%v", r, foo.er, foo)
+		}
+	}
+}
+
+func TestMatchHostnames(t *testing.T) {
+	fooTests := []struct {
+		pattern string
+		host    string
+		er      bool
+	}{
+		{"*.cluster.local.", "foo1.cluster.local.", true},
+		{"foo1.cluster.local.", "foo2.cluster.local.", false},
+		{"cluster.local.", "foo1.cluster.local.", false},
+		{".", "foo1.cluster.local.", false},
+		{"cluster.local.", ".", false},
+	}
+
+	for _, foo := range fooTests {
+		r := matchHostnames(foo.pattern, foo.host)
+		if r != foo.er {
+			t.Errorf("Returned %v but expected %v for foo=%v", r, foo.er, foo)
+		}
+	}
+}
+
+func TestMergeLocationAnnotations(t *testing.T) {
+	// initial parameters
+	loc := ingress.Location{}
+	annotations := map[string]interface{}{
+		"Path":               "/checkpath",
+		"IsDefBackend":       true,
+		"Backend":            "foo_backend",
+		"BasicDigestAuth":    auth.BasicDigest{},
+		DeniedKeyName:        &fakeError{},
+		"EnableCORS":         true,
+		"ExternalAuth":       authreq.External{},
+		"RateLimit":          ratelimit.RateLimit{},
+		"Redirect":           rewrite.Redirect{},
+		"Whitelist":          ipwhitelist.SourceRange{},
+		"Proxy":              proxy.Configuration{},
+		"CertificateAuth":    resolver.AuthSSLCert{},
+		"UsePortInRedirects": true,
+	}
+
+	// create test table
+	type fooMergeLocationAnnotationsStruct struct {
+		fName string
+		er    interface{}
+	}
+	fooTests := []fooMergeLocationAnnotationsStruct{}
+	for name, value := range annotations {
+		fva := fooMergeLocationAnnotationsStruct{name, value}
+		fooTests = append(fooTests, fva)
+	}
+
+	// execute test
+	mergeLocationAnnotations(&loc, annotations)
+
+	// check result
+	for _, foo := range fooTests {
+		fv := reflect.ValueOf(loc).FieldByName(foo.fName).Interface()
+		if !reflect.DeepEqual(fv, foo.er) {
+			t.Errorf("Returned %v but expected %v for the field %s", fv, foo.er, foo.fName)
+		}
+	}
+	if _, ok := annotations[DeniedKeyName]; ok {
+		t.Errorf("%s should be removed after mergeLocationAnnotations", DeniedKeyName)
 	}
 }

--- a/core/pkg/ingress/sort_ingress_test.go
+++ b/core/pkg/ingress/sort_ingress_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func buildBackendByNameServers() BackendByNameServers {
+	return []*Backend{
+		{
+			Name:      "foo1",
+			Secure:    true,
+			Endpoints: []Endpoint{},
+		},
+		{
+			Name:      "foo2",
+			Secure:    false,
+			Endpoints: []Endpoint{},
+		},
+		{
+			Name:      "foo3",
+			Secure:    true,
+			Endpoints: []Endpoint{},
+		},
+	}
+}
+
+func TestBackendByNameServersLen(t *testing.T) {
+	fooTests := []struct {
+		backends BackendByNameServers
+		el       int
+	}{
+		{[]*Backend{}, 0},
+		{buildBackendByNameServers(), 3},
+		{nil, 0},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.backends.Len()
+		if r != fooTest.el {
+			t.Errorf("returned %v but expected %v for the len of BackendByNameServers: %v", r, fooTest.el, fooTest.backends)
+		}
+	}
+}
+
+func TestBackendByNameServersSwap(t *testing.T) {
+	fooTests := []struct {
+		backends BackendByNameServers
+		i        int
+		j        int
+	}{
+		{buildBackendByNameServers(), 0, 1},
+		{buildBackendByNameServers(), 2, 1},
+	}
+
+	for _, fooTest := range fooTests {
+		fooi := fooTest.backends[fooTest.i]
+		fooj := fooTest.backends[fooTest.j]
+		fooTest.backends.Swap(fooTest.i, fooTest.j)
+		if fooi.Name != fooTest.backends[fooTest.j].Name || fooj.Name != fooTest.backends[fooTest.i].Name {
+			t.Errorf("failed to swap for ByNameServers, foo: %v", fooTest)
+		}
+	}
+}
+
+func TestBackendByNameServersLess(t *testing.T) {
+	fooTests := []struct {
+		backends BackendByNameServers
+		i        int
+		j        int
+		er       bool
+	}{
+		// order by name
+		{buildBackendByNameServers(), 0, 2, true},
+		{buildBackendByNameServers(), 1, 0, false},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.backends.Less(fooTest.i, fooTest.j)
+		if r != fooTest.er {
+			t.Errorf("returned %v but expected %v for the foo: %v", r, fooTest.er, fooTest)
+		}
+	}
+}
+
+func buildEndpointByAddrPort() EndpointByAddrPort {
+	return []Endpoint{
+		{
+			Address:     "127.0.0.1",
+			Port:        "8080",
+			MaxFails:    3,
+			FailTimeout: 10,
+		},
+		{
+			Address:     "127.0.0.1",
+			Port:        "8081",
+			MaxFails:    3,
+			FailTimeout: 10,
+		},
+		{
+			Address:     "127.0.0.1",
+			Port:        "8082",
+			MaxFails:    3,
+			FailTimeout: 10,
+		},
+		{
+			Address:     "127.0.0.2",
+			Port:        "8082",
+			MaxFails:    3,
+			FailTimeout: 10,
+		},
+	}
+}
+
+func TestEndpointByAddrPortLen(t *testing.T) {
+	fooTests := []struct {
+		endpoints EndpointByAddrPort
+		el        int
+	}{
+		{[]Endpoint{}, 0},
+		{buildEndpointByAddrPort(), 4},
+		{nil, 0},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.endpoints.Len()
+		if r != fooTest.el {
+			t.Errorf("returned %v but expected %v for the len of EndpointByAddrPort: %v", r, fooTest.el, fooTest.endpoints)
+		}
+	}
+}
+
+func TestEndpointByAddrPortSwap(t *testing.T) {
+	fooTests := []struct {
+		endpoints EndpointByAddrPort
+		i         int
+		j         int
+	}{
+		{buildEndpointByAddrPort(), 0, 1},
+		{buildEndpointByAddrPort(), 2, 1},
+	}
+
+	for _, fooTest := range fooTests {
+		fooi := fooTest.endpoints[fooTest.i]
+		fooj := fooTest.endpoints[fooTest.j]
+		fooTest.endpoints.Swap(fooTest.i, fooTest.j)
+		if fooi.Port != fooTest.endpoints[fooTest.j].Port ||
+			fooi.Address != fooTest.endpoints[fooTest.j].Address ||
+			fooj.Port != fooTest.endpoints[fooTest.i].Port ||
+			fooj.Address != fooTest.endpoints[fooTest.i].Address {
+			t.Errorf("failed to swap for EndpointByAddrPort, foo: %v", fooTest)
+		}
+	}
+}
+
+func TestEndpointByAddrPortLess(t *testing.T) {
+	fooTests := []struct {
+		endpoints EndpointByAddrPort
+		i         int
+		j         int
+		er        bool
+	}{
+		// 1) order by name
+		// 2) order by port(if the name is the same one)
+		{buildEndpointByAddrPort(), 0, 1, true},
+		{buildEndpointByAddrPort(), 2, 1, false},
+		{buildEndpointByAddrPort(), 2, 3, true},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.endpoints.Less(fooTest.i, fooTest.j)
+		if r != fooTest.er {
+			t.Errorf("returned %v but expected %v for the foo: %v", r, fooTest.er, fooTest)
+		}
+	}
+}
+
+func buildServerByName() ServerByName {
+	return []*Server{
+		{
+			Hostname:       "foo1",
+			SSLPassthrough: true,
+			SSLCertificate: "foo1_cert",
+			SSLPemChecksum: "foo1_pem",
+			Locations:      []*Location{},
+		},
+		{
+			Hostname:       "foo2",
+			SSLPassthrough: true,
+			SSLCertificate: "foo2_cert",
+			SSLPemChecksum: "foo2_pem",
+			Locations:      []*Location{},
+		},
+		{
+			Hostname:       "foo3",
+			SSLPassthrough: false,
+			SSLCertificate: "foo3_cert",
+			SSLPemChecksum: "foo3_pem",
+			Locations:      []*Location{},
+		},
+		{
+			Hostname:       "_",
+			SSLPassthrough: false,
+			SSLCertificate: "foo4_cert",
+			SSLPemChecksum: "foo4_pem",
+			Locations:      []*Location{},
+		},
+	}
+}
+
+func TestServerByNameLen(t *testing.T) {
+	fooTests := []struct {
+		servers ServerByName
+		el      int
+	}{
+		{[]*Server{}, 0},
+		{buildServerByName(), 4},
+		{nil, 0},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.servers.Len()
+		if r != fooTest.el {
+			t.Errorf("returned %v but expected %v for the len of ServerByName: %v", r, fooTest.el, fooTest.servers)
+		}
+	}
+}
+
+func TestServerByNameSwap(t *testing.T) {
+	fooTests := []struct {
+		servers ServerByName
+		i       int
+		j       int
+	}{
+		{buildServerByName(), 0, 1},
+		{buildServerByName(), 2, 1},
+	}
+
+	for _, fooTest := range fooTests {
+		fooi := fooTest.servers[fooTest.i]
+		fooj := fooTest.servers[fooTest.j]
+		fooTest.servers.Swap(fooTest.i, fooTest.j)
+		if fooi.Hostname != fooTest.servers[fooTest.j].Hostname ||
+			fooj.Hostname != fooTest.servers[fooTest.i].Hostname {
+			t.Errorf("failed to swap for ServerByName, foo: %v", fooTest)
+		}
+	}
+}
+
+func TestServerByNameLess(t *testing.T) {
+	fooTests := []struct {
+		servers ServerByName
+		i       int
+		j       int
+		er      bool
+	}{
+		{buildServerByName(), 0, 1, true},
+		{buildServerByName(), 2, 1, false},
+		{buildServerByName(), 2, 3, false},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.servers.Less(fooTest.i, fooTest.j)
+		if r != fooTest.er {
+			t.Errorf("returned %v but expected %v for the foo: %v", r, fooTest.er, fooTest)
+		}
+	}
+}
+
+func buildLocationByPath() LocationByPath {
+	return []*Location{
+		{
+			Path:         "a",
+			IsDefBackend: true,
+			Backend:      "a_back",
+		},
+		{
+			Path:         "b",
+			IsDefBackend: true,
+			Backend:      "b_back",
+		},
+		{
+			Path:         "c",
+			IsDefBackend: true,
+			Backend:      "c_back",
+		},
+	}
+}
+
+func TestLocationByPath(t *testing.T) {
+	fooTests := []struct {
+		locations LocationByPath
+		el        int
+	}{
+		{[]*Location{}, 0},
+		{buildLocationByPath(), 3},
+		{nil, 0},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.locations.Len()
+		if r != fooTest.el {
+			t.Errorf("returned %v but expected %v for the len of LocationByPath: %v", r, fooTest.el, fooTest.locations)
+		}
+	}
+}
+
+func TestLocationByPathSwap(t *testing.T) {
+	fooTests := []struct {
+		locations LocationByPath
+		i         int
+		j         int
+	}{
+		{buildLocationByPath(), 0, 1},
+		{buildLocationByPath(), 2, 1},
+	}
+
+	for _, fooTest := range fooTests {
+		fooi := fooTest.locations[fooTest.i]
+		fooj := fooTest.locations[fooTest.j]
+		fooTest.locations.Swap(fooTest.i, fooTest.j)
+		if fooi.Path != fooTest.locations[fooTest.j].Path ||
+			fooj.Path != fooTest.locations[fooTest.i].Path {
+			t.Errorf("failed to swap for LocationByPath, foo: %v", fooTest)
+		}
+	}
+}
+
+func TestLocationByPathLess(t *testing.T) {
+	fooTests := []struct {
+		locations LocationByPath
+		i         int
+		j         int
+		er        bool
+	}{
+		// sorts location by path in descending order
+		{buildLocationByPath(), 0, 1, false},
+		{buildLocationByPath(), 2, 1, true},
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.locations.Less(fooTest.i, fooTest.j)
+		if r != fooTest.er {
+			t.Errorf("returned %v but expected %v for the foo: %v", r, fooTest.er, fooTest)
+		}
+	}
+}
+
+func TestGetObjectKindForSSLCert(t *testing.T) {
+	fk := &SSLCert{
+		ObjectMeta:  api.ObjectMeta{},
+		CAFileName:  "ca_file",
+		PemFileName: "pemfile",
+		PemSHA:      "pem_sha",
+		CN:          []string{},
+	}
+
+	r := fk.GetObjectKind()
+	if r == nil {
+		t.Errorf("Returned nil but expected a valid ObjectKind")
+	}
+}


### PR DESCRIPTION
This PR corrects the behaviour of default-ssl-certificate

**WARNING** - There is a breaking change here. Now the directive default-ssl-certificate is mandatory, and also it's existence. If there's no default-ssl-certificate the ingress controller deployment will fail.

When the Ingress Controller starts, it tries to fetch a default SSL Certificate to be used on the default backend service.

Also, when a user configures a ingress controller with the 'tls' directive, but doesn't specify the secret to be used, the default will be used instead.

This PR is related to issue #163 and also is a proposal. 