### PR TITLE
Add initialization of proxy variable

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -244,6 +244,8 @@ http {
         {{ end }}
         
         location {{ $path }} {
+            set $proxy_upstream_name "{{ $location.Backend }}";
+
             {{ if isLocationAllowed $location }}
             {{ if gt (len $location.Whitelist.CIDR) 0 }}
             {{ range $ip := $location.Whitelist.CIDR }}
@@ -319,7 +321,6 @@ http {
             proxy_set_header                        Accept-Encoding     "";
             {{ end }}
 
-            set $proxy_upstream_name "{{ $location.Backend }}";
             {{ buildProxyPass $backends $location }}
             {{ else }}
             #{{ $location.Denied }}


### PR DESCRIPTION
This change is to avoid setting the variable after any operation that can alter the process of the request (like a redirect)