### PR TITLE
Allows the usage of Default SSL Cert

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -203,7 +203,11 @@ http {
         server_name {{ $server.Hostname }};
         listen [::]:80{{ if $cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $index 0 }} ipv6only=off{{end}}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $backlogSize }}{{end}};
         {{/* Listen on 442 because port 443 is used in the stream section */}}
-        {{ if not (empty $server.SSLCertificate) }}listen 442 {{ if $cfg.UseProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.UseHTTP2 }}http2{{ end }};
+	{{ if not (empty $server.SSLCertificate) }}listen 442 {{ if $cfg.UseProxyProtocol }}proxy_protocol{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $backlogSize }}{{end}} ssl {{ if $cfg.UseHTTP2 }}http2{{ end }};
+          {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
+          # PEM sha: {{ $server.SSLPemChecksum }}
+          ssl_certificate                         {{ $server.SSLCertificate }};
+
         {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
         # PEM sha: {{ $server.SSLPemChecksum }}
         ssl_certificate                         {{ $server.SSLCertificate }};


### PR DESCRIPTION
This PR corrects the behaviour of default-ssl-certificate

When the Ingress Controller starts, it tries to fetch a default SSL Certificate to be used on the default backend service.

Also, when a user configures a ingress controller with the 'tls' directive, but doesn't specify the secret to be used (or specify an incorrect one), the default will be used instead.

This PR is related to issue #163 and replaces the #170 