### PR TITLE
Always docker --pull when building to fetch latest base images

### DIFF
--- a/controllers/gce/Makefile
+++ b/controllers/gce/Makefile
@@ -8,7 +8,7 @@ server:
 	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o  glbc *.go
 
 container: server
-	docker build -t $(PREFIX):$(TAG) .
+	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
 	gcloud docker push $(PREFIX):$(TAG)

--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -21,7 +21,7 @@ build: clean
 		-o rootfs/nginx-ingress-controller ${PKG}/pkg/cmd/controller
 
 container: build
-	docker build -t $(PREFIX):$(RELEASE) rootfs
+	docker build --pull -t $(PREFIX):$(RELEASE) rootfs
 
 push: container
 	gcloud docker push $(PREFIX):$(RELEASE)


### PR DESCRIPTION
`gcr.io/google_containers/glbc` is based on `ubuntu:14.04`, so it's important that we use the latest version of it each time we build this image.