### PR TITLE
Fix panic if a tempfile cannot be created

### DIFF
--- a/core/pkg/net/ssl/ssl.go
+++ b/core/pkg/net/ssl/ssl.go
@@ -38,7 +38,7 @@ func AddOrUpdateCertAndKey(name string, cert, key, ca []byte) (*ingress.SSLCert,
 
 	tempPemFile, err := ioutil.TempFile(ingress.DefaultSSLDirectory, pemName)
 	if err != nil {
-		return nil, fmt.Errorf("could not create temp pem file %v: %v", tempPemFile.Name(), err)
+		return nil, fmt.Errorf("could not create temp pem file %v: %v", pemFileName, err)
 	}
 
 	_, err = tempPemFile.Write(cert)


### PR DESCRIPTION
A panic would be thrown if tempPemFile couldn't be created. Using a string variable to fix this.