### PR TITLE
Balancing mode UTILIZATION -> RATE 

### DIFF
--- a/controllers/gce/Makefile
+++ b/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.9.0
+TAG = 0.9.1
 PREFIX = gcr.io/google_containers/glbc
 
 server:

--- a/controllers/gce/README.md
+++ b/controllers/gce/README.md
@@ -327,7 +327,7 @@ So simply delete the replication controller:
 $ kubectl get rc glbc
 CONTROLLER   CONTAINER(S)           IMAGE(S)                                      SELECTOR                    REPLICAS   AGE
 glbc         default-http-backend   gcr.io/google_containers/defaultbackend:1.0   k8s-app=glbc,version=v0.5   1          2m
-             l7-lb-controller       gcr.io/google_containers/glbc:0.9.0
+             l7-lb-controller       gcr.io/google_containers/glbc:0.9.1
 
 $ kubectl delete rc glbc
 replicationcontroller "glbc" deleted

--- a/controllers/gce/backends/backends.go
+++ b/controllers/gce/backends/backends.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -31,6 +32,41 @@ import (
 	"k8s.io/ingress/controllers/gce/storage"
 	"k8s.io/ingress/controllers/gce/utils"
 )
+
+// BalancingMode represents the loadbalancing configuration of an individual
+// Backend in a BackendService. This is *effectively* a cluster wide setting
+// since you can't mix modes across Backends pointing to the same IG, and you
+// can't have a single node in more than 1 loadbalanced IG.
+type BalancingMode string
+
+const (
+	// Rate balances incoming requests based on observed RPS.
+	// As of this writing, it's the only balancing mode supported by GCE's
+	// internal LB. This setting doesn't make sense for Kubernets clusters
+	// because requests can get proxied between instance groups in different
+	// zones by kube-proxy without GCE even knowing it. Setting equal RPS on
+	// all IGs should achieve roughly equal distribution of requests.
+	Rate BalancingMode = "RATE"
+	// Utilization balances incoming requests based on observed utilization.
+	// This mode is only useful if you want to divert traffic away from IGs
+	// running other compute intensive workloads. Utilization statistics are
+	// aggregated per instances, not per container, and requests can get proxied
+	// between instance groups in different zones by kube-proxy without GCE even
+	// knowing about it.
+	Utilization BalancingMode = "UTILIZATION"
+	// Connections balances incoming requests based on a connection counter.
+	// This setting currently doesn't make sense for Kubernetes clusters,
+	// because we use NodePort Services as HTTP LB backends, so GCE's connection
+	// counters don't accurately represent connections per container.
+	Connections BalancingMode = "CONNECTION"
+)
+
+// maxRPS is the RPS setting for all Backends with BalancingMode RATE. The exact
+// value doesn't matter, as long as it's the same for all Backends. Requests
+// received by GCLB above this RPS are NOT dropped, GCLB continues to distribute
+// them across IGs.
+// TODO: Should this be math.MaxInt64?
+const maxRPS = 1
 
 // Backends implements BackendPool.
 type Backends struct {
@@ -116,20 +152,35 @@ func (b *Backends) create(igs []*compute.InstanceGroup, namedPort *compute.Named
 	if err != nil {
 		return nil, err
 	}
-	// Create a new backend
-	backend := &compute.BackendService{
-		Name:     name,
-		Protocol: "HTTP",
-		Backends: getBackendsForIGs(igs),
-		// Api expects one, means little to kubernetes.
-		HealthChecks: []string{hc.SelfLink},
-		Port:         namedPort.Port,
-		PortName:     namedPort.Name,
+	errs := []string{}
+	for _, bm := range []BalancingMode{Rate, Utilization} {
+		backends := getBackendsForIGs(igs)
+		for _, b := range backends {
+			switch bm {
+			case Rate:
+				b.MaxRate = maxRPS
+			default:
+				// TODO: Set utilization and connection limits when we accept them
+				// as valid fields.
+			}
+			b.BalancingMode = string(bm)
+		}
+		// Create a new backend
+		backend := &compute.BackendService{
+			Name:         name,
+			Protocol:     "HTTP",
+			Backends:     backends,
+			HealthChecks: []string{hc.SelfLink},
+			Port:         namedPort.Port,
+			PortName:     namedPort.Name,
+		}
+		if err := b.cloud.CreateBackendService(backend); err != nil {
+			glog.Infof("Error creating backend service with balancing mode %v", bm)
+			errs = append(errs, fmt.Sprintf("%v", err))
+		}
+		return b.Get(namedPort.Port)
 	}
-	if err := b.cloud.CreateBackendService(backend); err != nil {
-		return nil, err
-	}
-	return b.Get(namedPort.Port)
+	return nil, fmt.Errorf("%v", strings.Join(errs, "\n"))
 }
 
 // Add will get or create a Backend for the given port.

--- a/controllers/gce/controller/fakes.go
+++ b/controllers/gce/controller/fakes.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/sets"
 
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/ingress/controllers/gce/backends"
 	"k8s.io/ingress/controllers/gce/firewalls"
 	"k8s.io/ingress/controllers/gce/healthchecks"
@@ -45,7 +46,7 @@ type fakeClusterManager struct {
 // NewFakeClusterManager creates a new fake ClusterManager.
 func NewFakeClusterManager(clusterName string) *fakeClusterManager {
 	fakeLbs := loadbalancers.NewFakeLoadBalancers(clusterName)
-	fakeBackends := backends.NewFakeBackendServices()
+	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString())
 	fakeHCs := healthchecks.NewFakeHealthChecks()
 	namer := utils.NewNamer(clusterName)

--- a/controllers/gce/loadbalancers/loadbalancers_test.go
+++ b/controllers/gce/loadbalancers/loadbalancers_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T) LoadBalancerPool {
-	fakeBackends := backends.NewFakeBackendServices()
+	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString())
 	fakeHCs := healthchecks.NewFakeHealthChecks()
 	namer := &utils.Namer{}

--- a/controllers/gce/main.go
+++ b/controllers/gce/main.go
@@ -61,7 +61,7 @@ const (
 	alphaNumericChar = "0"
 
 	// Current docker image version. Only used in debug logging.
-	imageVersion = "glbc:0.9.0"
+	imageVersion = "glbc:0.9.1"
 
 	// Key used to persist UIDs to configmaps.
 	uidConfigMapName = "ingress-uid"

--- a/controllers/gce/rc.yaml
+++ b/controllers/gce/rc.yaml
@@ -24,18 +24,18 @@ metadata:
   name: l7-lb-controller
   labels:
     k8s-app: glbc
-    version: v0.9.0
+    version: v0.9.1
 spec:
   # There should never be more than 1 controller alive simultaneously.
   replicas: 1
   selector:
     k8s-app: glbc
-    version: v0.9.0
+    version: v0.9.1
   template:
     metadata:
       labels:
         k8s-app: glbc
-        version: v0.9.0
+        version: v0.9.1
         name: glbc
     spec:
       terminationGracePeriodSeconds: 600
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.9.0
+      - image: gcr.io/google_containers/glbc:0.9.1
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Tested manually

Created ingress with version 0.8.0: 
```
$ kubectl get ing 
NAME      HOSTS     ADDRESS          PORTS     AGE
test      *         35.186.217.102   80, 443   2m
```

Updated to 0.9.1 and created another ingress, backends all end up in UTILIZATION
```
$ kubectl create -f ~/rtmp/ingress/ing.yaml 
ingress "echomap" created

$ kubectl get ing 
NAME      HOSTS     ADDRESS          PORTS     AGE
test      *         35.186.217.102   80, 443   12m
echomap   foo       35.186.236.70   80, 443   51s

$ for be in $(gcloud compute backend-services list | awk '{print $1}' | tail -n +2); do gcloud compute backend-services describe $be | grep -i balancingmode; done
- balancingMode: UTILIZATION
- balancingMode: UTILIZATION
- balancingMode: UTILIZATION
```

Then recreted them all, backends end up in RATE
```
$ kubectl delete ing --all
ingress "echomap" deleted
ingress "test" deleted

$ kubectl create -f test.yaml
ingress "test" created

$ kubectl get ing 
NAME      HOSTS     ADDRESS         PORTS     AGE
test      *         35.186.230.43   80, 443   1m

$ for be in $(gcloud compute backend-services list | awk '{print $1}' | tail -n +2); do gcloud compute backend-services describe $be | grep -i balancingm
- balancingMode: RATE
- balancingMode: RATE
```