### PR TITLE
Adds support for disabling access_log globally

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -188,6 +188,9 @@ Setting at least one code also enables [proxy_intercept_errors](http://nginx.org
 Example usage: `custom-http-errors: 404,415`
 
 
+**disable-access-log:** Disables the Access Log from the entire Ingress Controller. This is 'false' by default.
+
+
 **enable-dynamic-tls-records:** Enables dynamically sized TLS records to improve time-to-first-byte. Enabled by default. See [CloudFlare's blog](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency) for more information.
 
 

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -88,6 +88,10 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size
 	ClientHeaderBufferSize string `json:"client-header-buffer-size"`
 
+	// DisableAccessLog disables the Access Log globally from NGINX ingress controller
+	//http://nginx.org/en/docs/http/ngx_http_log_module.html
+	DisableAccessLog bool `json:"disable-access-log,omitempty"`
+
 	// EnableSPDY enables spdy and use ALPN and NPN to advertise the availability of the two protocols
 	// https://blog.cloudflare.com/open-sourcing-our-nginx-http-2-spdy-code
 	// By default this is enabled
@@ -233,6 +237,7 @@ type Configuration struct {
 func NewDefault() Configuration {
 	cfg := Configuration{
 		ClientHeaderBufferSize:  "1k",
+		DisableAccessLog:        false,
 		EnableDynamicTLSRecords: true,
 		EnableSPDY:              false,
 		ErrorLogLevel:           errorLevel,

--- a/controllers/nginx/pkg/template/configmap_test.go
+++ b/controllers/nginx/pkg/template/configmap_test.go
@@ -39,12 +39,14 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"proxy-send-timeout":         "2",
 		"skip-access-log-urls":       "/log,/demo,/test",
 		"use-proxy-protocol":         "true",
+		"disable-access-log":         "true",
 		"use-gzip":                   "true",
 		"enable-dynamic-tls-records": "false",
 		"gzip-types":                 "text/html",
 	}
 	def := config.NewDefault()
 	def.CustomHTTPErrors = []int{300, 400}
+	def.DisableAccessLog = true
 	def.SkipAccessLogURLs = []string{"/log", "/demo", "/test"}
 	def.ProxyReadTimeout = 1
 	def.ProxySendTimeout = 2

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -87,7 +87,11 @@ http {
         default 1;
     }
 
+    {{ if $cfg.DisableAccessLog }}
+    access_log off;
+    {{ else }}
     access_log /var/log/nginx/access.log upstreaminfo if=$loggable;
+    {{ end }}
     error_log  /var/log/nginx/error.log {{ $cfg.ErrorLogLevel }};
 
     {{ buildResolvers $cfg.Resolver }}
@@ -424,7 +428,12 @@ stream {
 
     log_format log_stream '$remote_addr [$time_local] $protocol [$ssl_preread_server_name] [$stream_upstream] $status $bytes_sent $bytes_received $session_time';
 
+    {{ if $cfg.DisableAccessLog }}
+    access_log off;
+    {{ else }}
     access_log /var/log/nginx/access.log log_stream;
+    {{ end }}
+
     error_log  /var/log/nginx/error.log;
 
     # configure default backend for SSL


### PR DESCRIPTION
This PR adds support for disabling the access_log globally, through a directive in ConfigMap.

It's related to issue #234 

