### PR TITLE
Fix rewrite annotation parser

### DIFF
--- a/core/pkg/ingress/annotations/rewrite/main.go
+++ b/core/pkg/ingress/annotations/rewrite/main.go
@@ -52,11 +52,7 @@ func NewParser(br resolver.DefaultBackend) parser.IngressAnnotation {
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to rewrite the defined paths
 func (a rewrite) Parse(ing *extensions.Ingress) (interface{}, error) {
-	rt, err := parser.GetStringAnnotation(rewriteTo, ing)
-	if err != nil {
-		return nil, err
-	}
-
+	rt, _ := parser.GetStringAnnotation(rewriteTo, ing)
 	sslRe, err := parser.GetBoolAnnotation(sslRedirect, ing)
 	if err != nil {
 		sslRe = a.backendResolver.GetDefaultBackend().SSLRedirect

--- a/core/pkg/ingress/annotations/rewrite/main_test.go
+++ b/core/pkg/ingress/annotations/rewrite/main_test.go
@@ -76,8 +76,8 @@ func (m mockBackend) GetDefaultBackend() defaults.Backend {
 func TestWithoutAnnotations(t *testing.T) {
 	ing := buildIngress()
 	_, err := NewParser(mockBackend{}).Parse(ing)
-	if err == nil {
-		t.Error("Expected error with ingress without annotations")
+	if err != nil {
+		t.Errorf("unexpected error with ingress without annotations: %v", err)
 	}
 }
 


### PR DESCRIPTION
We need to return a Redirect type and not an error in order to get information about the SSL redirect defined in the backend

fixes #264 
fixes #160 
