### PR TITLE
fix wrong link in the file of examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Ingress examples
 
 This directory contains a catalog of examples on how to run, configure and
-scale Ingress. Please review the [prerequisities](prerequisites.md) before
+scale Ingress. Please review the [prerequisities](PREREQUISITES.md) before
 trying them.
 
 ## Basic cross platform


### PR DESCRIPTION
    fix wrong link in the file of examples/README.md, thank you!