### PR TITLE
[ubuntu-slim] Release ubuntu-slim 0.7

### DIFF
--- a/images/ubuntu-slim/Dockerfile.build
+++ b/images/ubuntu-slim/Dockerfile.build
@@ -7,6 +7,7 @@ COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
 RUN apt-get update \
     && apt-get dist-upgrade -y
 
+# no-op script removes the need for systemd-sysv
 COPY runlevel /sbin/runlevel
 
 # hold required packages to avoid breaking the installation of packages
@@ -14,10 +15,17 @@ RUN apt-mark hold apt gnupg adduser passwd libsemanage1
 
 # dpkg --get-selections | grep -v deinstall
 RUN echo "Yes, do as I say!" | apt-get purge \
+    e2fslibs \
     libcap2-bin \
     libkmod2 \
+    libmount1 \
+    libncursesw5 \
+    libprocps4 \
     libsmartcols1 \
     libudev1 \
+    ncurses-base \
+    ncurses-bin \
+    locales \
     tzdata
 
 # cleanup

--- a/images/ubuntu-slim/Makefile
+++ b/images/ubuntu-slim/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-TAG ?= 0.6
+TAG ?= 0.7
 PREFIX ?= gcr.io/google_containers/ubuntu-slim
 BUILD_IMAGE ?= ubuntu-build
 TAR_FILE ?= rootfs.tar

--- a/images/ubuntu-slim/README.md
+++ b/images/ubuntu-slim/README.md
@@ -1,9 +1,9 @@
 
 Small Ubuntu 16.04 docker image
 
-The size of this image is ~56MB (less than half than `ubuntu:16.04).
+The size of this image is ~44MB (less than half than `ubuntu:16.04).
 This is possible by the removal of packages that are not required in a container:
-- dmsetup
+- e2fslibs
 - e2fsprogs
 - init
 - initscripts
@@ -11,12 +11,16 @@ This is possible by the removal of packages that are not required in a container
 - libcryptsetup4
 - libdevmapper1.02.1
 - libkmod2
+- libmount1
+- libncursesw5
+- libprocps4
 - libsmartcols1
 - libudev1
 - mount
+- ncurses-base
+- ncurses-bin
 - procps
 - systemd
 - systemd-sysv
 - tzdata
-- udev
 - util-linux


### PR DESCRIPTION
Thanks to @timstclair for cleaning the `Dockerfile.build` file.

This release reduces the size in 14MB.