### PR TITLE
GCE/GKE "pre-shared" TLS cert

### DIFF
--- a/controllers/gce/controller/controller.go
+++ b/controllers/gce/controller/controller.go
@@ -431,6 +431,7 @@ func (lbc *LoadBalancerController) ListRuntimeInfo() (lbs []*loadbalancers.L7Run
 		lbs = append(lbs, &loadbalancers.L7RuntimeInfo{
 			Name:         k,
 			TLS:          tls,
+			TLSName:      annotations.useNamedTLS(),
 			AllowHTTP:    annotations.allowHTTP(),
 			StaticIPName: annotations.staticIPName(),
 		})

--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -45,6 +45,13 @@ const (
 	// rules for port 443 based on the TLS section.
 	allowHTTPKey = "kubernetes.io/ingress.allow-http"
 
+	// useNamedTLS tells the Ingress controller to use a specific GCE
+	// SSL certificate for its target proxies. If specified, the Ingress controller
+	// assigns the SSL certifiate by this name to the target proxies of the given
+	// Ingress. The controller *does not* manage this certificate, it is the users
+	// responsibility to create/delete it.
+	useNamedTLS = "kubernetes.io/ingress.use-named-tls"
+
 	// staticIPNameKey tells the Ingress controller to use a specific GCE
 	// static ip for its forwarding rules. If specified, the Ingress controller
 	// assigns the static ip by this name to the forwarding rules of the given

--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -87,7 +87,6 @@ func (ing ingAnnotations) allowHTTP() bool {
 }
 
 // useNamedTLS returns the name of the GCE SSL certificate. Empty by default.
-// TODO: naming this (ie: external-ssl-cert)
 func (ing ingAnnotations) useNamedTLS() string {
 	val, ok := ing[preSharedCertKey]
 	if !ok {

--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -50,6 +50,7 @@ const (
 	// assigns the SSL certifiate by this name to the target proxies of the given
 	// Ingress. The controller *does not* manage this certificate, it is the users
 	// responsibility to create/delete it.
+	// TODO: naming this (ie: external-ssl-cert)
 	useNamedTLS = "kubernetes.io/ingress.use-named-tls"
 
 	// staticIPNameKey tells the Ingress controller to use a specific GCE

--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -86,6 +86,15 @@ func (ing ingAnnotations) allowHTTP() bool {
 	return v
 }
 
+func (ing ingAnnotations) useNamedTLS() string {
+	val, ok := ing[useNamedTLS]
+	if !ok {
+		return ""
+	}
+
+	return val
+}
+
 func (ing ingAnnotations) staticIPName() string {
 	val, ok := ing[staticIPNameKey]
 	if !ok {

--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -52,6 +52,13 @@ const (
 	// responsibility to create/delete it.
 	staticIPNameKey = "kubernetes.io/ingress.global-static-ip-name"
 
+	// preSharedCertKey represents the specific pre-shared SSL
+	// certicate for the Ingress controller to use. The controller *does not*
+	// manage this certificate, it is the users responsibility to create/delete it.
+	// In GCP, the Ingress controller assigns the SSL certificate with this name
+	// to the target proxies of the Ingress.
+	preSharedCertKey = "ingress.gcp.kubernetes.io/pre-shared-cert"
+
 	// ingressClassKey picks a specific "class" for the Ingress. The controller
 	// only processes Ingresses with this annotation either unset, or set
 	// to either gceIngessClass or the empty string.
@@ -82,7 +89,7 @@ func (ing ingAnnotations) allowHTTP() bool {
 // useNamedTLS returns the name of the GCE SSL certificate. Empty by default.
 // TODO: naming this (ie: external-ssl-cert)
 func (ing ingAnnotations) useNamedTLS() string {
-	val, ok := ing[extensions.IngressPreSharedCertAnnotationKey]
+	val, ok := ing[preSharedCertKey]
 	if !ok {
 		return ""
 	}

--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -45,14 +45,6 @@ const (
 	// rules for port 443 based on the TLS section.
 	allowHTTPKey = "kubernetes.io/ingress.allow-http"
 
-	// useNamedTLS tells the Ingress controller to use a specific GCE
-	// SSL certificate for its target proxies. If specified, the Ingress controller
-	// assigns the SSL certifiate by this name to the target proxies of the given
-	// Ingress. The controller *does not* manage this certificate, it is the users
-	// responsibility to create/delete it.
-	// TODO: naming this (ie: external-ssl-cert)
-	useNamedTLS = "kubernetes.io/ingress.use-named-tls"
-
 	// staticIPNameKey tells the Ingress controller to use a specific GCE
 	// static ip for its forwarding rules. If specified, the Ingress controller
 	// assigns the static ip by this name to the forwarding rules of the given
@@ -87,8 +79,10 @@ func (ing ingAnnotations) allowHTTP() bool {
 	return v
 }
 
+// useNamedTLS returns the name of the GCE SSL certificate. Empty by default.
+// TODO: naming this (ie: external-ssl-cert)
 func (ing ingAnnotations) useNamedTLS() string {
-	val, ok := ing[useNamedTLS]
+	val, ok := ing[extensions.IngressPreSharedCertAnnotationKey]
 	if !ok {
 		return ""
 	}

--- a/controllers/gce/loadbalancers/loadbalancers.go
+++ b/controllers/gce/loadbalancers/loadbalancers.go
@@ -358,9 +358,8 @@ func (l *L7) checkSSLCert() (err error) {
 
 	namedCert := l.runtimeInfo.TLSName
 
-	// Use the named GCE cert if specified by the annotation.
+	// Use the named GCE cert when it is specified by the annotation.
 	if namedCert != "" {
-		glog.Infof("-- %s: Using namedCert %s for certName", l.runtimeInfo.Name, namedCert)
 		certName := namedCert
 
 		// Use the targetHTTPSProxy's cert name if one already exists.
@@ -369,14 +368,14 @@ func (l *L7) checkSSLCert() (err error) {
 		}
 		cert, _ := l.cloud.GetSslCertificate(certName)
 
-		if cert == nil {
-			glog.Warningf("-- %s: Uh oh, no cert found by %f", l.runtimeInfo.Name, certName)
+		if cert != nil {
+			glog.Infof("Using existing sslCertificate %v for %v", certName, l.Name)
+
+			l.sslCert = cert
+			return nil
 		}
 
-		glog.Infof("-- %s: Got cert name: %s, cert: %+v, name: %s, selflink: %s", l.runtimeInfo.Name, certName, cert, cert.Name, cert.SelfLink)
-		//cert.SelfLink = cert.Name
-		l.sslCert = cert
-		return nil
+		glog.Warningf("-- %s: Uh oh, no cert found by %f", l.runtimeInfo.Name, certName)
 	}
 
 	ingCert := l.runtimeInfo.TLS.Cert

--- a/controllers/gce/loadbalancers/loadbalancers.go
+++ b/controllers/gce/loadbalancers/loadbalancers.go
@@ -375,7 +375,7 @@ func (l *L7) checkSSLCert() (err error) {
 			return nil
 		}
 
-		glog.Warningf("-- %s: Uh oh, no cert found by %f", l.runtimeInfo.Name, certName)
+		return fmt.Errorf("Cannot find existing sslCertificate %v for %v", certName, l.Name)
 	}
 
 	ingCert := l.runtimeInfo.TLS.Cert

--- a/controllers/gce/loadbalancers/loadbalancers.go
+++ b/controllers/gce/loadbalancers/loadbalancers.go
@@ -958,6 +958,9 @@ func GetLBAnnotations(l7 *L7, existing map[string]string, backendPool backends.B
 	if l7.ip != nil {
 		existing[fmt.Sprintf("%v/static-ip", utils.K8sAnnotationPrefix)] = l7.ip.Name
 	}
+	if l7.sslCert != nil {
+		existing[fmt.Sprintf("%v/ssl-cert", utils.K8sAnnotationPrefix)] = l7.sslCert.Name
+	}
 	// TODO: We really want to know *when* a backend flipped states.
 	existing[fmt.Sprintf("%v/backends", utils.K8sAnnotationPrefix)] = jsonBackendState
 	return existing


### PR DESCRIPTION
**What this PR does / why we need it**:
- Ingress can reference to an external TLS cert
- ~~Ingress does not use TLS secret if a reference exists~~ (pending validation code)
- unit test to create an Ingress with the annotation

**Which issue this PR fixes**:
Closes #45.
Related to https://github.com/kubernetes/kubernetes/pull/41593.

**Special notes for your reviewer**:
- [x] there is a `TODO` item on naming of this annotation key.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
