### PR TITLE
Update makefile gcloud docker command

### DIFF
--- a/controllers/gce/Makefile
+++ b/controllers/gce/Makefile
@@ -11,7 +11,7 @@ container: server
 	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX):$(TAG)
+	gcloud docker -- push $(PREFIX):$(TAG)
 
 clean:
 	rm -f glbc

--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -24,7 +24,7 @@ container: build
 	docker build --pull -t $(PREFIX):$(RELEASE) rootfs
 
 push: container
-	gcloud docker push $(PREFIX):$(RELEASE)
+	gcloud docker -- push $(PREFIX):$(RELEASE)
 
 fmt:
 	@echo "+ $@"

--- a/examples/custom-controller/Makefile
+++ b/examples/custom-controller/Makefile
@@ -32,7 +32,7 @@ container: server
 	docker build --pull -t $(PREFIX)-$(ARCH):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX)-$(ARCH):$(TAG)
+	gcloud docker -- push $(PREFIX)-$(ARCH):$(TAG)
 
 clean:
 	rm -f server

--- a/images/nginx-slim/Makefile
+++ b/images/nginx-slim/Makefile
@@ -8,7 +8,7 @@ container:
 	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX):$(TAG)
+	gcloud docker -- push $(PREFIX):$(TAG)
 
 clean:
 	docker rmi -f $(PREFIX):$(TAG) || true


### PR DESCRIPTION
Add `--` between gcloud and docker args:

```
WARNING: The '--' argument must be specified between gcloud specific args on the left and DOCKER_ARGS on the right. IMPORTANT: previously, commands allowed the omission of the --, and unparsed arguments were treated as implementation args. This usage is being deprecated and will be removed in March 2017.
This will be strictly enforced in March 2017. Use 'gcloud beta docker' to see new behavior.
```