### PR TITLE
Sort stream service ports to avoid extra reloads

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -522,6 +522,8 @@ func (ic *GenericController) getStreamServices(configmapName string, proto api.P
 		})
 	}
 
+	sort.Sort(ingress.LocationByPath(svcs))
+
 	return svcs
 }
 


### PR DESCRIPTION
This fixes a bug where an Ingress controller would continuously reload its configuration if multiple TCP/UDP stream services were specified. This is caused by the list of ports not being sorted.