### PR TITLE
[ingress/controllers/nginx] Add whitelistSourceRange of global config to location block in template

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -256,8 +256,14 @@ http {
             {{ range $ip := $location.Whitelist.CIDR }}
             allow {{ $ip }};{{ end }}
             deny all;
+            {{ else }}
+            {{ if gt (len $cfg.WhitelistSourceRange) 0 }}
+            {{ range $ip := $cfg.WhitelistSourceRange}}
+            allow {{ $ip }};{{ end }}
+            deny all;
             {{ end }}
-            
+            {{ end }}
+
             port_in_redirect {{ if $location.UsePortInRedirects }}on{{ else }}off{{ end }};
 
             {{ if not (empty $authPath) }}


### PR DESCRIPTION
The current nginx.tmpl only takes into account `ingress.kubernetes.io/whitelist-source-range` set on an Ingress but doesn't seem to take into account `whitelist-source-range` set in the Configmap of Nginx.

According to the docs at https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md it should take that into account though:
> To configure this setting globally for all Ingress rules, the whitelist-source-range value may be set in the NGINX ConfigMap.
> Note: Adding an annotation to an Ingress rule overrides any global restriction.

This pull request add's the `whitelist-source-range` information to nginx.tmpl, only if for the location no specific one is set.