### PR TITLE
Fix for formatting error introduced in #304.

### DIFF
--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -126,15 +126,15 @@ var (
 			}
 			return true
 		},
-		"buildLocation":               buildLocation,
-		"buildAuthLocation":           buildAuthLocation,
-		"buildProxyPass":              buildProxyPass,
-		"buildRateLimitZones":         buildRateLimitZones,
-		"buildRateLimit":              buildRateLimit,
+		"buildLocation":                buildLocation,
+		"buildAuthLocation":            buildAuthLocation,
+		"buildProxyPass":               buildProxyPass,
+		"buildRateLimitZones":          buildRateLimitZones,
+		"buildRateLimit":               buildRateLimit,
 		"buildSSLPassthroughUpstreams": buildSSLPassthroughUpstreams,
-		"buildResolvers":              buildResolvers,
-		"isLocationAllowed":           isLocationAllowed,
-		"buildStreamUpstreams":        buildStreamUpstreams,
+		"buildResolvers":               buildResolvers,
+		"isLocationAllowed":            isLocationAllowed,
+		"buildStreamUpstreams":         buildStreamUpstreams,
 
 		"contains":  strings.Contains,
 		"hasPrefix": strings.HasPrefix,


### PR DESCRIPTION
Why don't we fail the travis build when go fmt is unhappy?