### PR TITLE
Do not run coverage check in the default target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: fmt lint vet cover
+all: fmt lint vet
 
 BUILDTAGS=
 


### PR DESCRIPTION
Reasons:
- this takes a lot longer than the other steps
- its results are harder to interpret at a single glance, compared to other
  steps
- it requires special privileges to succeed, and should probably not be ran
  from a random developer's checkout, since it pushes results to a shared
  service