### PR TITLE
Enable custom election id for status sync.

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -134,6 +134,7 @@ type Configuration struct {
 	Backend ingress.Controller
 
 	UpdateStatus bool
+	ElectionID   string
 }
 
 // newIngressController creates an Ingress controller
@@ -303,6 +304,7 @@ func newIngressController(config *Configuration) *GenericController {
 			Client:         config.Client,
 			PublishService: ic.cfg.PublishService,
 			IngressLister:  ic.ingLister,
+			ElectionID:     config.ElectionID,
 		})
 	} else {
 		glog.Warning("Update of ingress status is disabled (flag --update-status=false was specified)")

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -82,6 +82,8 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 
 		updateStatus = flags.Bool("update-status", true, `Indicates if the 
 		ingress controller should update the Ingress status IP/hostname. Default is true`)
+
+		electionID = flags.String("election-id", "ingress-controller-leader", `Election id to use for status update.`)
 	)
 
 	backend.OverrideFlags(flags)
@@ -137,6 +139,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 
 	config := &Configuration{
 		UpdateStatus:          *updateStatus,
+		ElectionID:            *electionID,
 		Client:                kubeClient,
 		ResyncPeriod:          *resyncPeriod,
 		DefaultService:        *defaultSvc,

--- a/core/pkg/ingress/status/status.go
+++ b/core/pkg/ingress/status/status.go
@@ -52,6 +52,7 @@ type Config struct {
 	Client         clientset.Interface
 	PublishService string
 	IngressLister  cache_store.StoreToIngressLister
+	ElectionID     string
 }
 
 // statusSync keeps the status IP in each Ingress rule updated executing a periodic check
@@ -171,7 +172,7 @@ func NewStatusSyncer(config Config) Sync {
 	}
 	st.syncQueue = task.NewCustomTaskQueue(st.sync, st.keyfunc)
 
-	le, err := NewElection("ingress-controller-leader",
+	le, err := NewElection(config.ElectionID,
 		pod.Name, pod.Namespace, 30*time.Second,
 		st.callback, config.Client)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it:**
- Multiple deployment/repliaset/daemonset of same ingress controller class can not work correctly in a same namespace.

**Which issue this PR fixes:**
Closes #350

