### PR TITLE
Fix ingress class

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -48,9 +48,10 @@ const (
 )
 
 var (
-	tmplPath = "/etc/nginx/template/nginx.tmpl"
-	cfgPath  = "/etc/nginx/nginx.conf"
-	binary   = "/usr/sbin/nginx"
+	tmplPath        = "/etc/nginx/template/nginx.tmpl"
+	cfgPath         = "/etc/nginx/nginx.conf"
+	binary          = "/usr/sbin/nginx"
+	defIngressClass = "nginx"
 )
 
 // newNGINXController creates a new NGINX Ingress controller.
@@ -256,7 +257,12 @@ func (n NGINXController) Info() *ingress.BackendInfo {
 
 // OverrideFlags customize NGINX controller flags
 func (n NGINXController) OverrideFlags(flags *pflag.FlagSet) {
-	flags.Set("ingress-class", "nginx")
+	flags.Set("ingress-class", defIngressClass)
+}
+
+// DefaultIngressClass just return the default ingress class
+func (n NGINXController) DefaultIngressClass() string {
+	return defIngressClass
 }
 
 // testTemplate checks if the NGINX configuration inside the byte array is valid

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -127,6 +127,7 @@ type Configuration struct {
 	UDPConfigMapName      string
 	DefaultSSLCertificate string
 	DefaultHealthzURL     string
+	DefaultIngressClass   string
 	// optional
 	PublishService string
 	// Backend is the particular implementation to be used.
@@ -166,7 +167,7 @@ func newIngressController(config *Configuration) *GenericController {
 	ingEventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			addIng := obj.(*extensions.Ingress)
-			if !IsValidClass(addIng, config.IngressClass) {
+			if !IsValidClass(addIng, config) {
 				glog.Infof("ignoring add for ingress %v based on annotation %v", addIng.Name, ingressClassKey)
 				return
 			}
@@ -175,7 +176,7 @@ func newIngressController(config *Configuration) *GenericController {
 		},
 		DeleteFunc: func(obj interface{}) {
 			delIng := obj.(*extensions.Ingress)
-			if !IsValidClass(delIng, config.IngressClass) {
+			if !IsValidClass(delIng, config) {
 				glog.Infof("ignoring delete for ingress %v based on annotation %v", delIng.Name, ingressClassKey)
 				return
 			}
@@ -185,7 +186,7 @@ func newIngressController(config *Configuration) *GenericController {
 		UpdateFunc: func(old, cur interface{}) {
 			oldIng := old.(*extensions.Ingress)
 			curIng := cur.(*extensions.Ingress)
-			if !IsValidClass(curIng, config.IngressClass) && !IsValidClass(oldIng, config.IngressClass) {
+			if !IsValidClass(curIng, config) && !IsValidClass(oldIng, config) {
 				return
 			}
 
@@ -588,7 +589,7 @@ func (ic *GenericController) getBackendServers() ([]*ingress.Backend, []*ingress
 	for _, ingIf := range ings {
 		ing := ingIf.(*extensions.Ingress)
 
-		if !IsValidClass(ing, ic.cfg.IngressClass) {
+		if !IsValidClass(ing, ic.cfg) {
 			continue
 		}
 
@@ -711,7 +712,7 @@ func (ic *GenericController) createUpstreams(data []interface{}) map[string]*ing
 	for _, ingIf := range data {
 		ing := ingIf.(*extensions.Ingress)
 
-		if !IsValidClass(ing, ic.cfg.IngressClass) {
+		if !IsValidClass(ing, ic.cfg) {
 			continue
 		}
 
@@ -872,7 +873,7 @@ func (ic *GenericController) createServers(data []interface{},
 	// initialize all the servers
 	for _, ingIf := range data {
 		ing := ingIf.(*extensions.Ingress)
-		if !IsValidClass(ing, ic.cfg.IngressClass) {
+		if !IsValidClass(ing, ic.cfg) {
 			continue
 		}
 
@@ -912,7 +913,7 @@ func (ic *GenericController) createServers(data []interface{},
 	// configure default location and SSL
 	for _, ingIf := range data {
 		ing := ingIf.(*extensions.Ingress)
-		if !IsValidClass(ing, ic.cfg.IngressClass) {
+		if !IsValidClass(ing, ic.cfg) {
 			continue
 		}
 

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -144,6 +144,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		ResyncPeriod:          *resyncPeriod,
 		DefaultService:        *defaultSvc,
 		IngressClass:          *ingressClass,
+		DefaultIngressClass:   backend.DefaultIngressClass(),
 		Namespace:             *watchNamespace,
 		ConfigMapName:         *configMap,
 		TCPConfigMapName:      *tcpConfigMapName,

--- a/core/pkg/ingress/controller/util.go
+++ b/core/pkg/ingress/controller/util.go
@@ -88,20 +88,26 @@ func matchHostnames(pattern, host string) bool {
 // IsValidClass returns true if the given Ingress either doesn't specify
 // the ingress.class annotation, or it's set to the configured in the
 // ingress controller.
-func IsValidClass(ing *extensions.Ingress, class string) bool {
-	if class == "" {
-		return true
-	}
+func IsValidClass(ing *extensions.Ingress, config *Configuration) bool {
+	currentIngClass := config.IngressClass
 
 	cc, err := parser.GetStringAnnotation(ingressClassKey, ing)
 	if err != nil && !errors.IsMissingAnnotations(err) {
 		glog.Warningf("unexpected error reading ingress annotation: %v", err)
 	}
-	if cc == "" {
+
+	// we have 2 valid combinations
+	// 1 - ingress with default class | blank annotation on ingress
+	// 2 - ingress with specific class | same annotation on ingress
+	//
+	// and 2 invalid combinations
+	// 3 - ingress with default class | fixed annotation on ingress
+	// 4 - ingress with specific class | different annotation on ingress
+	if (cc == "" && currentIngClass == "") || (currentIngClass == config.DefaultIngressClass) {
 		return true
 	}
 
-	return cc == class
+	return cc == currentIngClass
 }
 
 func mergeLocationAnnotations(loc *ingress.Location, anns map[string]interface{}) {

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -96,6 +96,8 @@ type Controller interface {
 	Info() *BackendInfo
 	// OverrideFlags allow the customization of the flags in the backend
 	OverrideFlags(*pflag.FlagSet)
+	// DefaultIngressClass just return the default ingress class
+	DefaultIngressClass() string
 }
 
 // StoreLister returns the configured stores for ingresses, services,


### PR DESCRIPTION
## Description

When args ingress-class is empty, the default class is nginx so all the ingress without the annotation "kubernetes.io/ingress.class" must be builded. The current controller build all the ingress including ingress with anotation.

## Ex. empty arg 

Controller
```
containers:
      - args:
        - /nginx-ingress-controller    
....
```
## Empty class annotation (controller must build this)
```
kind: Ingress
metadata:
  annotations:    
    kubernetes.io/tls-acme: "true"
....
```


## Fixed class annotation (controller must NOT build this)
```
kind: Ingress

metadata:
  annotations:    
    kubernetes.io/tls-acme: "true"
    kubernetes.io/ingress.class: "my-fake-class"
....
```

On the other side when args ingress-class is configured, just the ingress with the same class must be builded.

## Ex. with ingress args

Controller
```
containers:
      - args:
        - /nginx-ingress-controller    
        - --ingress-class=internal-nginx
....
```
## Empty class annotation (controller must NOT build this)
```
kind: Ingress
metadata:
  annotations:    
    kubernetes.io/tls-acme: "true"
....
```

## Fixed class annotation (controller must build this)
```
kind: Ingress

metadata:
  annotations:    
    kubernetes.io/tls-acme: "true"
    kubernetes.io/ingress.class: "internal-nginx
....
```

Fix #282 
 