### PR TITLE
Fix error caused by increasing proxy_buffer_size (#363)

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -331,6 +331,7 @@ http {
             proxy_redirect                          off;
             proxy_buffering                         off;
             proxy_buffer_size                       "{{ $location.Proxy.BufferSize }}";
+            proxy_buffers                           4 "{{ $location.Proxy.BufferSize }}";
 
             proxy_http_version                      1.1;
 


### PR DESCRIPTION
This fixes the bug raised in #363, by increasing the size of the proxy_buffers (memory allocation) to match the size of the proxy buffer. This leaves the default values (with no ingress configmap setting) unchanged:
```
proxy_buffer_size     4k
proxy_buffers         4 4k
```
If 'proxy-buffer-size' is set then, with this patch, both the buffer size and the memory allocation size is increased:
```
proxy_buffer_size     "{{ $location.Proxy.BufferSize }}";
proxy_buffers         4 "{{ $location.Proxy.BufferSize }}";
```
I have been using this patch from some time with both 0.8.3 and 0.9.0-beta.2.