### PR TITLE
BuildLogFormatUpstream was always using the default log-format

### DIFF
--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -264,7 +264,7 @@ func NewDefault() Configuration {
 		KeepAlive:                75,
 		LargeClientHeaderBuffers: "4 8k",
 		LogFormatStream:          logFormatStream,
-		LogFormatUpstream:        BuildLogFormatUpstream(false),
+		LogFormatUpstream:        BuildLogFormatUpstream(false, ""),
 		MaxWorkerConnections:     16384,
 		MapHashBucketSize:        64,
 		ProxyRealIPCIDR:          defIPCIDR,
@@ -307,7 +307,14 @@ func NewDefault() Configuration {
 }
 
 // BuildLogFormatUpstream format the log_format upstream based on proxy_protocol
-func BuildLogFormatUpstream(useProxyProtocol bool) string {
+func BuildLogFormatUpstream(useProxyProtocol bool, curLogFormatUpstream string) string {
+
+	// test if log_format comes from configmap
+	if curLogFormatUpstream != "" &&
+		curLogFormatUpstream != fmt.Sprintf(logFormatUpstream, "$proxy_protocol_addr") &&
+		curLogFormatUpstream != fmt.Sprintf(logFormatUpstream, "$remote_addr") {
+		return curLogFormatUpstream
+	}
 
 	if useProxyProtocol {
 		return fmt.Sprintf(logFormatUpstream, "$proxy_protocol_addr")

--- a/controllers/nginx/pkg/config/config_test.go
+++ b/controllers/nginx/pkg/config/config_test.go
@@ -9,15 +9,18 @@ func TestBuildLogFormatUpstream(t *testing.T) {
 
 	testCases := []struct {
 		useProxyProtocol bool // use proxy protocol
+		curLogFormat     string
 		expected         string
 	}{
-		{true, fmt.Sprintf(logFormatUpstream, "$proxy_protocol_addr")},
-		{false, fmt.Sprintf(logFormatUpstream, "$remote_addr")},
+		{true, "", fmt.Sprintf(logFormatUpstream, "$proxy_protocol_addr")},
+		{false, "", fmt.Sprintf(logFormatUpstream, "$remote_addr")},
+		{true, "my-log-format", "my-log-format"},
+		{false, "john-log-format", "john-log-format"},
 	}
 
 	for _, testCase := range testCases {
 
-		result := BuildLogFormatUpstream(testCase.useProxyProtocol)
+		result := BuildLogFormatUpstream(testCase.useProxyProtocol, testCase.curLogFormat)
 
 		if result != testCase.expected {
 			t.Errorf(" expected %v but return %v", testCase.expected, result)

--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -235,7 +235,7 @@ func buildLogFormatUpstream(input interface{}) string {
 		glog.Errorf("error  an ingress.buildLogFormatUpstream type but %T was returned", input)
 	}
 
-	return nginxconfig.BuildLogFormatUpstream(config.UseProxyProtocol)
+	return nginxconfig.BuildLogFormatUpstream(config.UseProxyProtocol, config.LogFormatUpstream)
 
 }
 


### PR DESCRIPTION
In my last PR #352 I add the ability to customize the log-format using a configmap. 
When I change this configmap, the template doesn't apply the new value, because the function was always using the default values.