### PR TITLE
Minor text fix for "ApiServer"

### DIFF
--- a/controllers/README.md
+++ b/controllers/README.md
@@ -8,4 +8,4 @@ Configuring a webserver or loadbalancer is harder than it should be. Most webser
 
 ## What is an Ingress Controller?
 
-An Ingress Controller is a daemon, deployed as a Kubernetes Pod, that watches the ApiServer's `/ingresses` endpoint for updates to the [Ingress resource](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/ingress.md). Its job is to satisfy requests for ingress.
+An Ingress Controller is a daemon, deployed as a Kubernetes Pod, that watches the apiserver's `/ingresses` endpoint for updates to the [Ingress resource](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/ingress.md). Its job is to satisfy requests for ingress.


### PR DESCRIPTION
It looks a little weird to apply camel case style for the noun "apiserver", i didn't see somewhere else spelling it in that way.