### PR TITLE
Rebase GLBC on alpine:3.5

### DIFF
--- a/controllers/gce/Dockerfile
+++ b/controllers/gce/Dockerfile
@@ -12,23 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: use radial/busyboxplus:curl or alping instead
-FROM ubuntu:14.04
-MAINTAINER Prashanth B <beeps@google.com>
+FROM alpine:3.5
 
-# so apt-get doesn't complain
-ENV DEBIAN_FRONTEND=noninteractive
-RUN sed -i 's/^exit 101/exit 0/' /usr/sbin/policy-rc.d
+RUN apk add --no-cache ca-certificates
 
-# TODO: Move to using haproxy:1.5 image instead. Honestly,
-# that image isn't much smaller and the convenience of having
-# an ubuntu container for dev purposes trumps the tiny amounts
-# of disk and bandwidth we'd save in doing so.
-RUN \
-  apt-get update && \
-  apt-get install -y ca-certificates && \
-  apt-get install -y curl && \
-  rm -rf /var/lib/apt/lists/*
-
-ADD glbc glbc
+COPY glbc glbc
 ENTRYPOINT ["/glbc"]

--- a/controllers/gce/Makefile
+++ b/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.9.1
+TAG = 0.9.2
 PREFIX = gcr.io/google_containers/glbc
 
 server:

--- a/controllers/gce/README.md
+++ b/controllers/gce/README.md
@@ -327,7 +327,7 @@ So simply delete the replication controller:
 $ kubectl get rc glbc
 CONTROLLER   CONTAINER(S)           IMAGE(S)                                      SELECTOR                    REPLICAS   AGE
 glbc         default-http-backend   gcr.io/google_containers/defaultbackend:1.0   k8s-app=glbc,version=v0.5   1          2m
-             l7-lb-controller       gcr.io/google_containers/glbc:0.9.1
+             l7-lb-controller       gcr.io/google_containers/glbc:0.9.2
 
 $ kubectl delete rc glbc
 replicationcontroller "glbc" deleted
@@ -340,7 +340,7 @@ glbc-6m6b6              1/1       Terminating   0          13m
 __The prod way__: If you didn't start the controller with `--delete-all-on-quit`, you can execute a GET on the `/delete-all-and-quit` endpoint. This endpoint is deliberately not exported.
 
 ```
-$ kubectl exec -it glbc-6m6b6  -- curl http://localhost:8081/delete-all-and-quit
+$ kubectl exec -it glbc-6m6b6  -- wget -q -O- http://localhost:8081/delete-all-and-quit
 ..Hangs till quit is done..
 
 $ kubectl logs glbc-6m6b6  --follow

--- a/controllers/gce/main.go
+++ b/controllers/gce/main.go
@@ -62,7 +62,7 @@ const (
 	alphaNumericChar = "0"
 
 	// Current docker image version. Only used in debug logging.
-	imageVersion = "glbc:0.9.1"
+	imageVersion = "glbc:0.9.2"
 
 	// Key used to persist UIDs to configmaps.
 	uidConfigMapName = "ingress-uid"

--- a/controllers/gce/rc.yaml
+++ b/controllers/gce/rc.yaml
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.9.1
+      - image: gcr.io/google_containers/glbc:0.9.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -105,7 +105,7 @@ $ glbc --help
 		 pod secrets for creating a Kubernetes client. (default true)
 
 $ ./glbc --running-in-cluster=false
-I1210 17:49:53.202149   27767 main.go:179] Starting GLBC image: glbc:0.8.0, cluster name
+I1210 17:49:53.202149   27767 main.go:179] Starting GLBC image: glbc:0.9.2, cluster name
 ```
 
 Note that this is equivalent to running the ingress controller on your local

--- a/examples/deployment/gce/README.md
+++ b/examples/deployment/gce/README.md
@@ -43,7 +43,7 @@ $ kubectl create -f gce-tls-ingress.yaml
 ingress "test" created
 
 $ kubectl logs l7-lb-controller-1s22c -c l7-lb-controller
-I0201 01:03:17.387548       1 main.go:179] Starting GLBC image: glbc:0.9.0, cluster name
+I0201 01:03:17.387548       1 main.go:179] Starting GLBC image: glbc:0.9.2, cluster name
 I0201 01:03:18.459740       1 main.go:291] Using saved cluster uid "32658fa96c080068"
 I0201 01:03:18.459771       1 utils.go:122] Changing cluster name from  to 32658fa96c080068
 I0201 01:03:18.461652       1 gce.go:331] Using existing Token Source &oauth2.reuseTokenSource{new:google.computeSource{account:""}, mu:sync.Mutex{state:0, sema:0x0}, t:(*oauth2.Token)(nil)}

--- a/examples/deployment/gce/gce-ingress-controller.yaml
+++ b/examples/deployment/gce/gce-ingress-controller.yaml
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.9.0-beta.1
+      - image: gcr.io/google_containers/glbc:0.9.2
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/40248

Rebasing on busybox greatly reduces the size of the image. More importantly, it greatly reduces the management burden of keeping the image up-to-date in as all the packages within are updated.

@csbell @nicksardo 