### PR TITLE
Fix glbc usage string

### DIFF
--- a/controllers/gce/main.go
+++ b/controllers/gce/main.go
@@ -70,7 +70,7 @@ const (
 
 var (
 	flags = flag.NewFlagSet(
-		`gclb: gclb --runngin-in-cluster=false --default-backend-node-port=123`,
+		`glbc: glbc --running-in-cluster=false`,
 		flag.ExitOnError)
 
 	clusterName = flags.String("cluster-uid", controller.DefaultClusterUID,


### PR DESCRIPTION
1. Typo in `glbc` binary name
2. Typo in `running-in-cluster` flag
3. Remove non-existing flag `--default-backend-node-port`