### PR TITLE
remove tmp nginx-diff files

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -223,6 +223,7 @@ func (n NGINXController) isReloadRequired(data []byte) bool {
 			glog.Infof("NGINX configuration diff\n")
 			glog.Infof("%v", string(diffOutput))
 		}
+		os.Remove(tmpfile.Name())
 		return len(diffOutput) > 0
 	}
 	return false


### PR DESCRIPTION
I noticed the disk usage of the nginx container had grown to about 5GB caused by +30k nginx-diff-xxxx files in /tmp. This PR removes those files once they're no longer needed.