### PR TITLE
Fix add-base-url

### DIFF
--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -205,7 +205,13 @@ func buildLocation(input interface{}) string {
 		if path == "/" {
 			return fmt.Sprintf("~* %s", path)
 		}
-		return fmt.Sprintf("~* ^%s", path)
+		// baseuri regex will parse basename from the given location
+		baseuri := `(?<baseuri>.*)`
+		if !strings.HasSuffix(path, slash) {
+			// Not treat the slash after "location path" as a part of baseuri
+			baseuri = fmt.Sprintf(`\/?%s`, baseuri)
+		}
+		return fmt.Sprintf(`~* ^%s%s`, path, baseuri)
 	}
 
 	return path
@@ -273,13 +279,10 @@ func buildProxyPass(b interface{}, loc interface{}) string {
 	if len(location.Redirect.Target) > 0 {
 		abu := ""
 		if location.Redirect.AddBaseURL {
-			bPath := location.Redirect.Target
-			if !strings.HasSuffix(bPath, slash) {
-				bPath = fmt.Sprintf("%s/", bPath)
-			}
-
-			abu = fmt.Sprintf(`subs_filter '<head(.*)>' '<head$1><base href="$scheme://$server_name%v">' r;
-	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$server_name%v">' r;
+			// path has a slash suffix, so that it can be connected with baseuri directly
+			bPath := fmt.Sprintf("%s%s", path, "$baseuri")
+			abu = fmt.Sprintf(`subs_filter '<head(.*)>' '<head$1><base href="$scheme://$http_host%v">' r;
+	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$http_host%v">' r;
 	`, bPath, bPath)
 		}
 

--- a/controllers/nginx/pkg/template/template_test.go
+++ b/controllers/nginx/pkg/template/template_test.go
@@ -45,33 +45,43 @@ var (
 	rewrite /(.*) /jenkins/$1 break;
 	proxy_pass http://upstream-name;
 	`, false},
-		"redirect /something to /": {"/something", "/", "~* ^/something", `
+		"redirect /something to /": {"/something", "/", `~* ^/something\/?(?<baseuri>.*)`, `
 	rewrite /something/(.*) /$1 break;
 	rewrite /something / break;
 	proxy_pass http://upstream-name;
 	`, false},
-		"redirect /something-complex to /not-root": {"/something-complex", "/not-root", "~* ^/something-complex", `
+		"redirect /end-with-slash/ to /not-root": {"/end-with-slash/", "/not-root", "~* ^/end-with-slash/(?<baseuri>.*)", `
+	rewrite /end-with-slash/(.*) /not-root/$1 break;
+	proxy_pass http://upstream-name;
+	`, false},
+		"redirect /something-complex to /not-root": {"/something-complex", "/not-root", `~* ^/something-complex\/?(?<baseuri>.*)`, `
 	rewrite /something-complex/(.*) /not-root/$1 break;
 	proxy_pass http://upstream-name;
 	`, false},
 		"redirect / to /jenkins and rewrite": {"/", "/jenkins", "~* /", `
 	rewrite /(.*) /jenkins/$1 break;
 	proxy_pass http://upstream-name;
-	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$server_name/jenkins/">' r;
-	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$server_name/jenkins/">' r;
+	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$http_host/$baseuri">' r;
+	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$http_host/$baseuri">' r;
 	`, true},
-		"redirect /something to / and rewrite": {"/something", "/", "~* ^/something", `
+		"redirect /something to / and rewrite": {"/something", "/", `~* ^/something\/?(?<baseuri>.*)`, `
 	rewrite /something/(.*) /$1 break;
 	rewrite /something / break;
 	proxy_pass http://upstream-name;
-	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$server_name/">' r;
-	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$server_name/">' r;
+	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$http_host/something/$baseuri">' r;
+	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$http_host/something/$baseuri">' r;
 	`, true},
-		"redirect /something-complex to /not-root and rewrite": {"/something-complex", "/not-root", "~* ^/something-complex", `
+		"redirect /end-with-slash/ to /not-root and rewrite": {"/end-with-slash/", "/not-root", `~* ^/end-with-slash/(?<baseuri>.*)`, `
+	rewrite /end-with-slash/(.*) /not-root/$1 break;
+	proxy_pass http://upstream-name;
+	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$http_host/end-with-slash/$baseuri">' r;
+	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$http_host/end-with-slash/$baseuri">' r;
+	`, true},
+		"redirect /something-complex to /not-root and rewrite": {"/something-complex", "/not-root", `~* ^/something-complex\/?(?<baseuri>.*)`, `
 	rewrite /something-complex/(.*) /not-root/$1 break;
 	proxy_pass http://upstream-name;
-	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$server_name/not-root/">' r;
-	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$server_name/not-root/">' r;
+	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$http_host/something-complex/$baseuri">' r;
+	subs_filter '<HEAD(.*)>' '<HEAD$1><base href="$scheme://$http_host/something-complex/$baseuri">' r;
 	`, true},
 	}
 )


### PR DESCRIPTION
Fix issue #67 

HTML "base" tag is written for browser.

### Correct way
"base" tag should be: `hostname/location/basename/`.
Then, a browser sends the request, something like this`<base>/filename`, to Nginx.
Then, this URI is translated into `service/target/basename/filename` by Nginx.

### Problem
However, in current code, it misses the `basename` part, and confuses the 'location' and 'target'.

### Solution
When the request comes to Nginx, the "basename" should be parsed at the entrance, in `buildLocation` method.

### Bug
There are 2 bugs in current "AddBaseURL":
1. When the rule's `host` field is an empty string, the "base" will be generated as `_`, which is wrong. The base-uri hostname should be the one in the HTTP request, `$http_host`.
2. Described in #67. Miss the basename part in base-uri, so that Nginx cannot find the resources. Even the unit-test cases, the `subs_filter` parts, are wrongly designed.

### Example
For the most complex case:

If we define a redirect rule like this,

| From  | To  |
|:-:|:-:|
| hostname/FROM  | service/TO  |

Then, we fetch a web page, `hostname/FROM/dist/index.html`
Inside this page's header, the `<base>` tag is generated:

| ❌ wrong "base" tag | ✅ correct "base" tag |
|:-:|:-:|
| hostname/TO/  | hostname/FROM/dist/  |

And, when this web page requests for a JS resource with a link `js/main.js`,

| ❌ wrong page sends | ✅ correct page sends |
|:-:|:-:|
| hostname/TO/js/main.js  | hostname/FROM/dist/js/main.js |

Of course, the wrong based request will get a 404.