### PR TITLE
Avoid a nil-reference when the temporary file cannot be created

### DIFF
--- a/core/pkg/net/ssl/ssl.go
+++ b/core/pkg/net/ssl/ssl.go
@@ -43,10 +43,10 @@ func AddOrUpdateCertAndKey(name string, cert, key, ca []byte) (*ingress.SSLCert,
 
 	tempPemFile, err := ioutil.TempFile(ingress.DefaultSSLDirectory, pemName)
 
-	glog.V(3).Infof("Creating temp file %v for Keypair: %v", tempPemFile.Name(), pemName)
 	if err != nil {
 		return nil, fmt.Errorf("could not create temp pem file %v: %v", pemFileName, err)
 	}
+	glog.V(3).Infof("Creating temp file %v for Keypair: %v", tempPemFile.Name(), pemName)
 
 	_, err = tempPemFile.Write(cert)
 	if err != nil {


### PR DESCRIPTION
I hit this one when trying to run the controller outside of kubernetes as per the development documentation. Eventually I gave up on that, but this fix is still valid :)