### PR TITLE
add hostNetwork

### DIFF
--- a/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
+++ b/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
@@ -12,6 +12,7 @@ spec:
         name: nginx-ingress-lb
     spec:
       terminationGracePeriodSeconds: 60
+      hostNetwork: true
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3
         name: nginx-ingress-lb

--- a/examples/deployment/nginx/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/nginx-ingress-controller.yaml
@@ -18,6 +18,7 @@ spec:
       # like with kubeadm
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
+      hostNetwork: true
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3
         name: nginx-ingress-controller


### PR DESCRIPTION
```
hostPort 
integer	Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
```
If HostNetwork is not specified，Node not listen