### PR TITLE
fix nginx-udp-and-udp on same port

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -490,7 +490,7 @@ stream {
 
     # TCP services
     {{ range $i, $tcpServer := .TCPBackends }}
-    upstream {{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }} {
+    upstream tcp-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }} {
     {{ range $j, $endpoint := $tcpServer.Endpoints }}
         server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
     {{ end }}
@@ -498,22 +498,22 @@ stream {
 
     server {
         listen                  {{ $tcpServer.Port }};
-        proxy_pass              {{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
+        proxy_pass              tcp-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
     }
     {{ end }}
 
     # UDP services
     {{ range $i, $udpServer := .UDPBackends }}
-    upstream {{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }} {
+    upstream udp-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }} {
     {{ range $j, $endpoint := $udpServer.Endpoints }}
         server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
     {{ end }}
     }
 
     server {
-        listen                  {{ $udpServer.Port }};
+        listen                  {{ $udpServer.Port }} udp;
         proxy_responses         1;
-        proxy_pass              {{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }};
+        proxy_pass              udp-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }};
     }
     {{ end }}
 }


### PR DESCRIPTION
In nginx-ingress-controller if using 
```
        - --udp-services-configmap=$(POD_NAMESPACE)/nginx-ingress-udp
        - --tcp-services-configmap=$(POD_NAMESPACE)/nginx-ingress-tcp
```
configs with same port, 53 for kube-dns as example:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: nginx-ingress-udp
data:
  53: "kube-system/kube-dns:53"
```
and 
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: nginx-ingress-tcp
data:
  53: "kube-system/kube-dns:53"
```

in nginx.conf will be created two upstreams with same name:
```
upstream kube-system-kube-dns-53 {...}
```
and nginx failing to start