### PR TITLE
Pass request port to real server

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -145,6 +145,12 @@ http {
         text             text/plain;
     }
 
+    # Obtain best http host
+    map $http_host $best_http_host {
+        default          $http_host;
+        ''               $host;
+    }
+
     server_name_in_redirect off;
     port_in_redirect        off;
 
@@ -240,7 +246,7 @@ http {
         {{ if (or $location.Redirect.ForceSSLRedirect (and (not (empty $server.SSLCertificate)) $location.Redirect.SSLRedirect)) }}
         # enforce ssl on server side
         if ($pass_access_scheme = http) {
-            return 301 https://$host$request_uri;
+            return 301 https://$best_http_host$request_uri;
         }
         {{ end }}
 
@@ -263,7 +269,7 @@ http {
             proxy_set_header X-Original-URI $request_uri;
             proxy_set_header X-Scheme       $pass_access_scheme;
             {{ end }}
-            proxy_set_header            Host $host;
+            proxy_set_header            Host $best_http_host;
             proxy_pass_request_headers  on;
             set $target {{ $location.ExternalAuth.URL }};
             proxy_pass $target;
@@ -314,7 +320,7 @@ http {
 
             client_max_body_size                    "{{ $location.Proxy.BodySize }}";
 
-            proxy_set_header Host                   $host;
+            proxy_set_header Host                   $best_http_host;
 
             # Pass the extracted client certificate to the backend
             {{ if not (empty $location.CertificateAuth.AuthSSLCert.CAFileName) }}
@@ -329,7 +335,7 @@ http {
             proxy_set_header                        Connection        $connection_upgrade;
 
             proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Host       $host;
+            proxy_set_header X-Forwarded-Host       $best_http_host;
             proxy_set_header X-Forwarded-Port       $pass_port;
             proxy_set_header X-Forwarded-Proto      $pass_access_scheme;
             proxy_set_header X-Original-URI         $request_uri;


### PR DESCRIPTION
What this PR does / why we need it:

If nginx ingress controller is behind some loadbalancer like haproxy, which redirect other port (not 80 or 443) to nginx ingress controller.
So request may looks like http://host:port. But nginx set Host and X-Forwarded-Host as $host, which without port like host. Therefore when real server send redirects to client requests, the url looks like http://host/redirect_url instead of correct url http://host:port/redirect_url.
If using $http_host instead of $host, the correct port will be passed to real server.

Which issue this PR fixes:

Closes #453 