### PR TITLE
[GLBC] Sync ingress when default backend service is modified.

### DIFF
--- a/controllers/gce/controller/utils.go
+++ b/controllers/gce/controller/utils.go
@@ -216,18 +216,29 @@ func (s *StoreToIngressLister) List() (ing extensions.IngressList, err error) {
 // GetServiceIngress gets all the Ingress' that have rules pointing to a service.
 // Note that this ignores services without the right nodePorts.
 func (s *StoreToIngressLister) GetServiceIngress(svc *api.Service) (ings []extensions.Ingress, err error) {
+IngressLoop:
 	for _, m := range s.Store.List() {
 		ing := *m.(*extensions.Ingress)
 		if ing.Namespace != svc.Namespace {
 			continue
 		}
-		for _, rules := range ing.Spec.Rules {
-			if rules.IngressRuleValue.HTTP == nil {
+
+		// Check service of default backend
+		if ing.Spec.Backend != nil && ing.Spec.Backend.ServiceName == svc.Name {
+			ings = append(ings, ing)
+			continue
+		}
+
+		// Check the target service for each path rule
+		for _, rule := range ing.Spec.Rules {
+			if rule.IngressRuleValue.HTTP == nil {
 				continue
 			}
-			for _, p := range rules.IngressRuleValue.HTTP.Paths {
+			for _, p := range rule.IngressRuleValue.HTTP.Paths {
 				if p.Backend.ServiceName == svc.Name {
 					ings = append(ings, ing)
+					// Skip the rest of the rules to avoid duplicate ingresses in list
+					continue IngressLoop
 				}
 			}
 		}


### PR DESCRIPTION
Given an ingress with a default backend. 

Example:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: my-echo-ingress
spec:
  backend:
    serviceName: my-echo-svc
    servicePort: 80
```

**Expectation**
If I were to modify the service `my-echo-svc`, I would expect the GLBC to sync all associated ingresses.

**Actual**
The sync is not triggered.

**Reason**
The function that searches through all ingresses for references to this service was not looking at the default backend.
