### PR TITLE
Use whitelist-source-range from configmap when no annotation on ingress.

### DIFF
--- a/core/pkg/ingress/annotations/ipwhitelist/main.go
+++ b/core/pkg/ingress/annotations/ipwhitelist/main.go
@@ -56,8 +56,9 @@ func (a ipwhitelist) Parse(ing *extensions.Ingress) (interface{}, error) {
 	sort.Strings(defBackend.WhitelistSourceRange)
 
 	val, err := parser.GetStringAnnotation(whitelist, ing)
-	if err != nil {
-		return &SourceRange{CIDR: defBackend.WhitelistSourceRange}, err
+	// A missing annotation is not a problem, just use the default
+	if err == ing_errors.ErrMissingAnnotations {
+		return &SourceRange{CIDR: defBackend.WhitelistSourceRange}, nil
 	}
 
 	values := strings.Split(val, ",")


### PR DESCRIPTION
Even though we were returning a SourceRange it was being ignored because we were also returning an error. Detect the case (and add tests) when the annotation is not present and use the BackendConfig in that case.

fixes #473
fixes #312