### PR TITLE
nginx-ingress-controller is built twice by docker-build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ controllers:
 	make -C controllers/nginx build
 
 .PHONY: docker-build
-docker-build: controllers
+docker-build:
 	make -C controllers/nginx container
 
 .PHONY: docker-push
-docker-push: docker-build
+docker-push:
 	make -C controllers/nginx push
 
 .PHONY: ginkgo


### PR DESCRIPTION
```
porridge@kielonek:~/projects/go/src/k8s.io/ingress$ make test-e2e 
go get github.com/onsi/ginkgo/ginkgo
2017/03/30 12:38:12 e2e.go:276: Running: build-release
make[1]: Entering directory `/usr/local/google/home/porridge/projects/go/src/k8s.io/ingress'
make -C controllers/nginx build
make[2]: Entering directory `/usr/local/google/home/porridge/projects/go/src/k8s.io/ingress/controllers/nginx'
rm -f rootfs/nginx-ingress-controller
CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
                -ldflags "-s -w -X k8s.io/ingress/controllers/nginx/pkg/version.RELEASE=0.9.0-beta.3 -X k8s.io/ingress/controllers/nginx/pkg/version.COMMIT=git-e385c05 -X k8s.io/ingress/controllers/nginx/pkg/ve
rsion.REPO=git@github.com:porridge/ingress.git" \
                -o rootfs/nginx-ingress-controller k8s.io/ingress/controllers/nginx/pkg/cmd/controller
make[2]: Leaving directory `/usr/local/google/home/porridge/projects/go/src/k8s.io/ingress/controllers/nginx'
make -C controllers/nginx container
make[2]: Entering directory `/usr/local/google/home/porridge/projects/go/src/k8s.io/ingress/controllers/nginx'
rm -f rootfs/nginx-ingress-controller
CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
                -ldflags "-s -w -X k8s.io/ingress/controllers/nginx/pkg/version.RELEASE=0.9.0-beta.3 -X k8s.io/ingress/controllers/nginx/pkg/version.COMMIT=git-e385c05 -X k8s.io/ingress/controllers/nginx/pkg/ve
rsion.REPO=git@github.com:porridge/ingress.git" \
                -o rootfs/nginx-ingress-controller k8s.io/ingress/controllers/nginx/pkg/cmd/controller
gcloud docker -- build --pull -t gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3 rootfs
[...]
```

Seems to be a waste of time...