### PR TITLE
Release ubuntu-slim:0.8

### DIFF
--- a/images/ubuntu-slim/Makefile
+++ b/images/ubuntu-slim/Makefile
@@ -1,7 +1,7 @@
 all: push
 
-TAG ?= 0.7
-PREFIX ?= gcr.io/google_containers/ubuntu-slim
+TAG ?= 0.8
+PREFIX ?= gcr.io/google-containers/ubuntu-slim
 BUILD_IMAGE ?= ubuntu-build
 TAR_FILE ?= rootfs.tar
 PUSH_TOOL ?= gcloud
@@ -13,7 +13,7 @@ container: clean
 	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
-	$(PUSH_TOOL) docker push $(PREFIX):$(TAG)
+	$(PUSH_TOOL) docker -- push $(PREFIX):$(TAG)
 
 clean:
 	docker rmi -f $(PREFIX):$(TAG) || true


### PR DESCRIPTION
This has no code changes, but it uses updated upstream dependencies with
fixes for the following:
* CVE-2016-1234
* CVE-2016-3706
* CVE-2016-4429
* CVE-2016-5417
* CVE-2016-6323
* CVE-2017-6507

I've already pushed `gcr.io/google-containers/ubuntu-slim:0.8`.

cc @nicksardo @aledbf 