### PR TITLE
Build namespace and ingress class as label

### DIFF
--- a/controllers/nginx/pkg/metric/collector/nginx.go
+++ b/controllers/nginx/pkg/metric/collector/nginx.go
@@ -17,18 +17,18 @@ limitations under the License.
 package collector
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type (
 	nginxStatusCollector struct {
-		scrapeChan    chan scrapeRequest
-		ngxHealthPort int
-		ngxVtsPath    string
-		data          *nginxStatusData
+		scrapeChan     chan scrapeRequest
+		ngxHealthPort  int
+		ngxVtsPath     string
+		data           *nginxStatusData
+		watchNamespace string
+		ingressClass   string
 	}
 
 	nginxStatusData struct {
@@ -42,62 +42,52 @@ type (
 	}
 )
 
-func buildNS(namespace, class string) string {
-	if namespace == "" {
-		namespace = "all"
-	}
-	if class == "" {
-		class = "all"
-	}
-
-	return fmt.Sprintf("%v_%v", namespace, class)
-}
-
 // NewNginxStatus returns a new prometheus collector the default nginx status module
-func NewNginxStatus(namespace, class string, ngxHealthPort int, ngxVtsPath string) Stopable {
-	p := nginxStatusCollector{
-		scrapeChan:    make(chan scrapeRequest),
-		ngxHealthPort: ngxHealthPort,
-		ngxVtsPath:    ngxVtsPath,
-	}
+func NewNginxStatus(watchNamespace, ingressClass string, ngxHealthPort int, ngxVtsPath string) Stopable {
 
-	ns := buildNS(namespace, class)
+	p := nginxStatusCollector{
+		scrapeChan:     make(chan scrapeRequest),
+		ngxHealthPort:  ngxHealthPort,
+		ngxVtsPath:     ngxVtsPath,
+		watchNamespace: watchNamespace,
+		ingressClass:   ingressClass,
+	}
 
 	p.data = &nginxStatusData{
 		active: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "active_connections"),
+			prometheus.BuildFQName(ns, "", "active_connections"),
 			"total number of active connections",
-			nil, nil),
+			[]string{"ingress_class", "namespace"}, nil),
 
 		accepted: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "accepted_connections"),
+			prometheus.BuildFQName(ns, "", "accepted_connections"),
 			"total number of accepted client connections",
-			nil, nil),
+			[]string{"ingress_class", "namespace"}, nil),
 
 		handled: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "handled_connections"),
+			prometheus.BuildFQName(ns, "", "handled_connections"),
 			"total number of handled connections",
-			nil, nil),
+			[]string{"ingress_class", "namespace"}, nil),
 
 		requests: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "total_requests"),
+			prometheus.BuildFQName(ns, "", "total_requests"),
 			"total number of client requests",
-			nil, nil),
+			[]string{"ingress_class", "namespace"}, nil),
 
 		reading: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "current_reading_connections"),
+			prometheus.BuildFQName(ns, "", "current_reading_connections"),
 			"current number of connections where nginx is reading the request header",
-			nil, nil),
+			[]string{"ingress_class", "namespace"}, nil),
 
 		writing: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "current_writing_connections"),
+			prometheus.BuildFQName(ns, "", "current_writing_connections"),
 			"current number of connections where nginx is writing the response back to the client",
-			nil, nil),
+			[]string{"ingress_class", "namespace"}, nil),
 
 		waiting: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "current_waiting_connections"),
+			prometheus.BuildFQName(ns, "", "current_waiting_connections"),
 			"current number of idle client connections waiting for a request",
-			nil, nil),
+			[]string{"ingress_class", "namespace"}, nil),
 	}
 
 	go p.start()
@@ -144,17 +134,17 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
 	}
 
 	ch <- prometheus.MustNewConstMetric(p.data.active,
-		prometheus.GaugeValue, float64(s.Active))
+		prometheus.GaugeValue, float64(s.Active), p.ingressClass, p.watchNamespace)
 	ch <- prometheus.MustNewConstMetric(p.data.accepted,
-		prometheus.GaugeValue, float64(s.Accepted))
+		prometheus.GaugeValue, float64(s.Accepted), p.ingressClass, p.watchNamespace)
 	ch <- prometheus.MustNewConstMetric(p.data.handled,
-		prometheus.GaugeValue, float64(s.Handled))
+		prometheus.GaugeValue, float64(s.Handled), p.ingressClass, p.watchNamespace)
 	ch <- prometheus.MustNewConstMetric(p.data.requests,
-		prometheus.GaugeValue, float64(s.Requests))
+		prometheus.GaugeValue, float64(s.Requests), p.ingressClass, p.watchNamespace)
 	ch <- prometheus.MustNewConstMetric(p.data.reading,
-		prometheus.GaugeValue, float64(s.Reading))
+		prometheus.GaugeValue, float64(s.Reading), p.ingressClass, p.watchNamespace)
 	ch <- prometheus.MustNewConstMetric(p.data.writing,
-		prometheus.GaugeValue, float64(s.Writing))
+		prometheus.GaugeValue, float64(s.Writing), p.ingressClass, p.watchNamespace)
 	ch <- prometheus.MustNewConstMetric(p.data.waiting,
-		prometheus.GaugeValue, float64(s.Waiting))
+		prometheus.GaugeValue, float64(s.Waiting), p.ingressClass, p.watchNamespace)
 }

--- a/controllers/nginx/pkg/metric/collector/vts.go
+++ b/controllers/nginx/pkg/metric/collector/vts.go
@@ -23,14 +23,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const system = "nginx"
+const ns = "nginx"
 
 type (
 	vtsCollector struct {
-		scrapeChan    chan scrapeRequest
-		ngxHealthPort int
-		ngxVtsPath    string
-		data          *vtsData
+		scrapeChan     chan scrapeRequest
+		ngxHealthPort  int
+		ngxVtsPath     string
+		data           *vtsData
+		watchNamespace string
+		ingressClass   string
 	}
 
 	vtsData struct {
@@ -55,100 +57,101 @@ type (
 )
 
 // NewNGINXVTSCollector returns a new prometheus collector for the VTS module
-func NewNGINXVTSCollector(namespace, class string, ngxHealthPort int, ngxVtsPath string) Stopable {
-	p := vtsCollector{
-		scrapeChan:    make(chan scrapeRequest),
-		ngxHealthPort: ngxHealthPort,
-		ngxVtsPath:    ngxVtsPath,
-	}
+func NewNGINXVTSCollector(watchNamespace, ingressClass string, ngxHealthPort int, ngxVtsPath string) Stopable {
 
-	ns := buildNS(namespace, class)
+	p := vtsCollector{
+		scrapeChan:     make(chan scrapeRequest),
+		ngxHealthPort:  ngxHealthPort,
+		ngxVtsPath:     ngxVtsPath,
+		watchNamespace: watchNamespace,
+		ingressClass:   ingressClass,
+	}
 
 	p.data = &vtsData{
 		bytes: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "bytes_total"),
+			prometheus.BuildFQName(ns, "", "bytes_total"),
 			"Nginx bytes count",
-			[]string{"server_zone", "direction"}, nil),
+			[]string{"ingress_class", "namespace", "server_zone", "direction"}, nil),
 
 		cache: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "cache_total"),
+			prometheus.BuildFQName(ns, "", "cache_total"),
 			"Nginx cache count",
-			[]string{"server_zone", "type"}, nil),
+			[]string{"ingress_class", "namespace", "server_zone", "type"}, nil),
 
 		connections: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "connections_total"),
+			prometheus.BuildFQName(ns, "", "connections_total"),
 			"Nginx connections count",
-			[]string{"type"}, nil),
+			[]string{"ingress_class", "namespace", "type"}, nil),
 
 		response: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "responses_total"),
+			prometheus.BuildFQName(ns, "", "responses_total"),
 			"The number of responses with status codes 1xx, 2xx, 3xx, 4xx, and 5xx.",
-			[]string{"server_zone", "status_code"}, nil),
+			[]string{"ingress_class", "namespace", "server_zone", "status_code"}, nil),
 
 		request: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "requests_total"),
+			prometheus.BuildFQName(ns, "", "requests_total"),
 			"The total number of requested client connections.",
-			[]string{"server_zone"}, nil),
+			[]string{"ingress_class", "namespace", "server_zone"}, nil),
 
 		filterZoneBytes: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "filterzone_bytes_total"),
+			prometheus.BuildFQName(ns, "", "filterzone_bytes_total"),
 			"Nginx bytes count",
-			[]string{"server_zone", "country", "direction"}, nil),
+			[]string{"ingress_class", "namespace", "server_zone", "country", "direction"}, nil),
 
 		filterZoneResponse: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "filterzone_responses_total"),
+			prometheus.BuildFQName(ns, "", "filterzone_responses_total"),
 			"The number of responses with status codes 1xx, 2xx, 3xx, 4xx, and 5xx.",
-			[]string{"server_zone", "country", "status_code"}, nil),
+			[]string{"ingress_class", "namespace", "server_zone", "country", "status_code"}, nil),
 
 		filterZoneCache: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "filterzone_cache_total"),
+			prometheus.BuildFQName(ns, "", "filterzone_cache_total"),
 			"Nginx cache count",
-			[]string{"server_zone", "country", "type"}, nil),
+			[]string{"ingress_class", "namespace", "server_zone", "country", "type"}, nil),
 
 		upstreamBackup: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_backup"),
+			prometheus.BuildFQName(ns, "", "upstream_backup"),
 			"Current backup setting of the server.",
-			[]string{"upstream", "server"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server"}, nil),
 
 		upstreamBytes: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_bytes_total"),
+			prometheus.BuildFQName(ns, "", "upstream_bytes_total"),
 			"The total number of bytes sent to this server.",
-			[]string{"upstream", "server", "direction"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server", "direction"}, nil),
 
 		upstreamDown: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "vts_upstream_down_total"),
+			prometheus.BuildFQName(ns, "", "vts_upstream_down_total"),
 			"Current down setting of the server.",
-			[]string{"upstream", "server"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server"}, nil),
 
 		upstreamFailTimeout: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_fail_timeout"),
+			prometheus.BuildFQName(ns, "", "upstream_fail_timeout"),
 			"Current fail_timeout setting of the server.",
-			[]string{"upstream", "server"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server"}, nil),
 
 		upstreamMaxFails: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_maxfails"),
+			prometheus.BuildFQName(ns, "", "upstream_maxfails"),
 			"Current max_fails setting of the server.",
-			[]string{"upstream", "server"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server"}, nil),
 
 		upstreamResponses: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_responses_total"),
+			prometheus.BuildFQName(ns, "", "upstream_responses_total"),
 			"The number of upstream responses with status codes 1xx, 2xx, 3xx, 4xx, and 5xx.",
-			[]string{"upstream", "server", "status_code"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server", "status_code"}, nil),
 
 		upstreamRequest: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_requests_total"),
+			prometheus.BuildFQName(ns, "", "upstream_requests_total"),
 			"The total number of client connections forwarded to this server.",
-			[]string{"upstream", "server"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server"}, nil),
 
 		upstreamResponseMsec: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_response_msecs_avg"),
+			prometheus.BuildFQName(ns, "", "upstream_response_msecs_avg"),
 			"The average of only upstream response processing times in milliseconds.",
-			[]string{"upstream", "server"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server"}, nil),
 
 		upstreamWeight: prometheus.NewDesc(
-			prometheus.BuildFQName(system, ns, "upstream_weight"),
+			prometheus.BuildFQName(ns, "", "upstream_weight"),
 			"Current upstream weight setting of the server.",
-			[]string{"upstream", "server"}, nil),
+			[]string{"ingress_class", "namespace", "upstream", "server"}, nil),
 	}
 
 	go p.start()
@@ -204,54 +207,54 @@ func (p vtsCollector) scrapeVts(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	reflectMetrics(&nginxMetrics.Connections, p.data.connections, ch)
+	reflectMetrics(&nginxMetrics.Connections, p.data.connections, ch, p.ingressClass, p.watchNamespace)
 
 	for name, zones := range nginxMetrics.UpstreamZones {
 		for pos, value := range zones {
-			reflectMetrics(&zones[pos].Responses, p.data.upstreamResponses, ch, name, value.Server)
+			reflectMetrics(&zones[pos].Responses, p.data.upstreamResponses, ch, p.ingressClass, p.watchNamespace, name, value.Server)
 
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamRequest,
-				prometheus.CounterValue, zones[pos].RequestCounter, name, value.Server)
+				prometheus.CounterValue, zones[pos].RequestCounter, p.ingressClass, p.watchNamespace, name, value.Server)
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamDown,
-				prometheus.CounterValue, float64(zones[pos].Down), name, value.Server)
+				prometheus.CounterValue, float64(zones[pos].Down), p.ingressClass, p.watchNamespace, name, value.Server)
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamWeight,
-				prometheus.CounterValue, zones[pos].Weight, name, value.Server)
+				prometheus.CounterValue, zones[pos].Weight, p.ingressClass, p.watchNamespace, name, value.Server)
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamResponseMsec,
-				prometheus.CounterValue, zones[pos].ResponseMsec, name, value.Server)
+				prometheus.CounterValue, zones[pos].ResponseMsec, p.ingressClass, p.watchNamespace, name, value.Server)
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamBackup,
-				prometheus.CounterValue, float64(zones[pos].Backup), name, value.Server)
+				prometheus.CounterValue, float64(zones[pos].Backup), p.ingressClass, p.watchNamespace, name, value.Server)
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamFailTimeout,
-				prometheus.CounterValue, zones[pos].FailTimeout, name, value.Server)
+				prometheus.CounterValue, zones[pos].FailTimeout, p.ingressClass, p.watchNamespace, name, value.Server)
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamMaxFails,
-				prometheus.CounterValue, zones[pos].MaxFails, name, value.Server)
+				prometheus.CounterValue, zones[pos].MaxFails, p.ingressClass, p.watchNamespace, name, value.Server)
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamBytes,
-				prometheus.CounterValue, zones[pos].InBytes, name, value.Server, "in")
+				prometheus.CounterValue, zones[pos].InBytes, p.ingressClass, p.watchNamespace, name, value.Server, "in")
 			ch <- prometheus.MustNewConstMetric(p.data.upstreamBytes,
-				prometheus.CounterValue, zones[pos].OutBytes, name, value.Server, "out")
+				prometheus.CounterValue, zones[pos].OutBytes, p.ingressClass, p.watchNamespace, name, value.Server, "out")
 		}
 	}
 
 	for name, zone := range nginxMetrics.ServerZones {
-		reflectMetrics(&zone.Responses, p.data.response, ch, name)
-		reflectMetrics(&zone.Cache, p.data.cache, ch, name)
+		reflectMetrics(&zone.Responses, p.data.response, ch, p.ingressClass, p.watchNamespace, name)
+		reflectMetrics(&zone.Cache, p.data.cache, ch, p.ingressClass, p.watchNamespace, name)
 
 		ch <- prometheus.MustNewConstMetric(p.data.request,
-			prometheus.CounterValue, zone.RequestCounter, name)
+			prometheus.CounterValue, zone.RequestCounter, p.ingressClass, p.watchNamespace, name)
 		ch <- prometheus.MustNewConstMetric(p.data.bytes,
-			prometheus.CounterValue, zone.InBytes, name, "in")
+			prometheus.CounterValue, zone.InBytes, p.ingressClass, p.watchNamespace, name, "in")
 		ch <- prometheus.MustNewConstMetric(p.data.bytes,
-			prometheus.CounterValue, zone.OutBytes, name, "out")
+			prometheus.CounterValue, zone.OutBytes, p.ingressClass, p.watchNamespace, name, "out")
 	}
 
 	for serverZone, countries := range nginxMetrics.FilterZones {
 		for country, zone := range countries {
-			reflectMetrics(&zone.Responses, p.data.filterZoneResponse, ch, serverZone, country)
-			reflectMetrics(&zone.Cache, p.data.filterZoneCache, ch, serverZone, country)
+			reflectMetrics(&zone.Responses, p.data.filterZoneResponse, ch, p.ingressClass, p.watchNamespace, serverZone, country)
+			reflectMetrics(&zone.Cache, p.data.filterZoneCache, ch, p.ingressClass, p.watchNamespace, serverZone, country)
 
 			ch <- prometheus.MustNewConstMetric(p.data.filterZoneBytes,
-				prometheus.CounterValue, float64(zone.InBytes), serverZone, country, "in")
+				prometheus.CounterValue, float64(zone.InBytes), p.ingressClass, p.watchNamespace, serverZone, country, "in")
 			ch <- prometheus.MustNewConstMetric(p.data.filterZoneBytes,
-				prometheus.CounterValue, float64(zone.OutBytes), serverZone, country, "out")
+				prometheus.CounterValue, float64(zone.OutBytes), p.ingressClass, p.watchNamespace, serverZone, country, "out")
 		}
 	}
 }


### PR DESCRIPTION
@aledbf  I made a mistake when I built the nginx nomenclature. The right way to fill namespace and ingress class is using labels, so it'll easy to filter and reuse.  

# Old format
![screen shot 2017-04-04 at 14 43 26](https://cloud.githubusercontent.com/assets/5694860/24658987/ae890926-194b-11e7-9410-da9ef002dfd5.png)

# New format
![screen shot 2017-04-04 at 14 44 04](https://cloud.githubusercontent.com/assets/5694860/24658988/aeb86158-194b-11e7-9c7c-6bea67640006.png)

# Alarm example

```
    ALERT NginxTooMany5XX
      IF sum by (ingress_class, status_code, server_zone) (rate(nginx_responses_total{status_code=~"[5]xx"}[5m]) ) > ( 1.1 * sum by (ingress_class, status_code, server_zone) (rate(nginx_responses_total{status_code=~"[5]xx"}[15m]) ) )
      LABELS {
        service = "nginx",
        severity = "critical"
      }
      ANNOTATIONS {
        summary = "Too many http 5XX errors,
        description = " Status code {{ $status_code }} increased 10% in the last 5 minutes. Ingress class {{ $labels.ingress_class }} on server zone {{ $labels.server_zone }}",
      }
```