### PR TITLE
Use SSLPassthrough if is Backend.Secure

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -697,7 +697,7 @@ func (ic *GenericController) getBackendServers() ([]*ingress.Backend, []*ingress
 								isHTTPSfrom = append(isHTTPSfrom, server)
 							}
 						}
-					} else {
+					} else if !upstream.Secure {
 						isHTTP = true
 					}
 				}


### PR DESCRIPTION
Use SSLPassthrough configuration also if a backend is tagged as Secure (uses TLS).

So the actual behaviour is: if some server tags a backend as plain HTTP (missing SSLPassthrough and Secure annotations), a misconfiguration is detected, the backend will be configured as plain HTTP and a warning is issued.