### PR TITLE
Revert merge annotations to the implicit root context

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -623,12 +623,6 @@ func (ic *GenericController) getBackendServers() ([]*ingress.Backend, []*ingress
 				server = servers[defServerName]
 			}
 
-			// Add annotations to location of default backend (root context)
-			if len(server.Locations) > 0 {
-				loc := server.Locations[0]
-				mergeLocationAnnotations(loc, anns)
-			}
-
 			if rule.HTTP == nil &&
 				host != defServerName {
 				glog.V(3).Infof("ingress rule %v/%v does not contain HTTP rules, using default backend", ing.Namespace, ing.Name)


### PR DESCRIPTION
This PR fixes #558 reverting #527. A proper fix I propose is to move `approot` from Location to Server struct. I can take care of this in the next few days. @aledbf what about the proposal?

@gianrubio FYI
