### PR TITLE
fixed lua_package_path in nginx.tmpl

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -43,7 +43,7 @@ http {
     {{ end }}
 
     # lua section to return proper error codes when custom pages are used
-    lua_package_path '.?.lua;./etc/nginx/lua/?.lua;/etc/nginx/lua/vendor/lua-resty-http/lib/?.lua;';
+    lua_package_path '.?.lua;/etc/nginx/lua/?.lua;/etc/nginx/lua/vendor/lua-resty-http/lib/?.lua;';
     init_by_lua_block {
         require("error_page")
     }


### PR DESCRIPTION
I did my own build of the nginx-ingress-controller and its docker image, but I had troubles with the `error_page.lua` module, which couldn't be loaded, there was an error in the log, module was not found.

I think the lua package path is wrong, here is a fix.