### PR TITLE
fix nginx ingress template keepalive

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -57,7 +57,7 @@ http {
 
     reset_timedout_connection on;
 
-    keepalive_timeout {{ $cfg.KeepAlive }}s;
+    keepalive_timeout {{if not $cfg.KeepAlive}}0{{end}}{{if $cfg.KeepAlive}}{{ $cfg.KeepAlive }}{{end}}s;
 
     client_header_buffer_size       {{ $cfg.ClientHeaderBufferSize }};
     large_client_header_buffers     {{ $cfg.LargeClientHeaderBuffers }};


### PR DESCRIPTION
There is a bug in nginx ingress controller where if keep-alive is set to 0 it actually results in "\<no value\>"