### PR TITLE
Move certificate auth from location to server

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -238,17 +238,17 @@ http {
 
         {{ if $cfg.EnableVtsStatus }}vhost_traffic_status_filter_by_set_key $geoip_country_code country::$server_name;{{ end }}
 
+        {{ if not (empty $server.CertificateAuth.AuthSSLCert.CAFileName) }}
+        # PEM sha: {{ $server.CertificateAuth.AuthSSLCert.PemSHA }}
+        ssl_client_certificate              {{ $server.CertificateAuth.AuthSSLCert.CAFileName }};
+        ssl_verify_client on;
+        ssl_verify_depth {{ $server.CertificateAuth.ValidationDepth }};
+        {{ end }}
+
         {{ range $location := $server.Locations }}
         {{ $path := buildLocation $location }}
         {{ $authPath := buildAuthLocation $location }}
 
-        {{ if not (empty $location.CertificateAuth.AuthSSLCert.CAFileName) }}
-        # PEM sha: {{ $location.CertificateAuth.AuthSSLCert.PemSHA }}
-        ssl_client_certificate              {{ $location.CertificateAuth.AuthSSLCert.CAFileName }};
-        ssl_verify_client on;
-        ssl_verify_depth {{ $location.CertificateAuth.ValidationDepth }};
-        {{ end }}
-        
         {{ if (or $location.Redirect.ForceSSLRedirect (and (not (empty $server.SSLCertificate)) $location.Redirect.SSLRedirect)) }}
         # enforce ssl on server side
         if ($pass_access_scheme = http) {
@@ -331,7 +331,7 @@ http {
             proxy_set_header Host                   $best_http_host;
 
             # Pass the extracted client certificate to the backend
-            {{ if not (empty $location.CertificateAuth.AuthSSLCert.CAFileName) }}
+            {{ if not (empty $server.CertificateAuth.AuthSSLCert.CAFileName) }}
             proxy_set_header ssl-client-cert        $ssl_client_cert;
             {{ end }}
 

--- a/core/pkg/ingress/controller/util_test.go
+++ b/core/pkg/ingress/controller/util_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/ingress/core/pkg/ingress"
 	"k8s.io/ingress/core/pkg/ingress/annotations/auth"
 	"k8s.io/ingress/core/pkg/ingress/annotations/authreq"
-	"k8s.io/ingress/core/pkg/ingress/annotations/authtls"
 	"k8s.io/ingress/core/pkg/ingress/annotations/ipwhitelist"
 	"k8s.io/ingress/core/pkg/ingress/annotations/proxy"
 	"k8s.io/ingress/core/pkg/ingress/annotations/ratelimit"
@@ -102,7 +101,6 @@ func TestMergeLocationAnnotations(t *testing.T) {
 		"Redirect":           rewrite.Redirect{},
 		"Whitelist":          ipwhitelist.SourceRange{},
 		"Proxy":              proxy.Configuration{},
-		"CertificateAuth":    authtls.AuthSSLConfig{},
 		"UsePortInRedirects": true,
 	}
 

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -212,6 +212,10 @@ type Server struct {
 	SSLPemChecksum string `json:"sslPemChecksum"`
 	// Locations list of URIs configured in the server.
 	Locations []*Location `json:"locations,omitempty"`
+	// CertificateAuth indicates the access to this location requires
+	// external authentication
+	// +optional
+	CertificateAuth authtls.AuthSSLConfig `json:"certificateAuth,omitempty"`
 }
 
 // Location describes an URI inside a server.
@@ -223,7 +227,6 @@ type Server struct {
 // In some cases when more than one annotations is defined a particular order in the execution
 // is required.
 // The chain in the execution order of annotations should be:
-// - CertificateAuth
 // - Whitelist
 // - RateLimit
 // - BasicDigestAuth
@@ -274,10 +277,6 @@ type Location struct {
 	// to be used in connections against endpoints
 	// +optional
 	Proxy proxy.Configuration `json:"proxy,omitempty"`
-	// CertificateAuth indicates the access to this location requires
-	// external authentication
-	// +optional
-	CertificateAuth authtls.AuthSSLConfig `json:"certificateAuth,omitempty"`
 	// UsePortInRedirects indicates if redirects must specify the port
 	// +optional
 	UsePortInRedirects bool `json:"use-port-in-redirects"`


### PR DESCRIPTION
I did this PR because nginx just accept one ssl_client_certificate per host (related to #571)

I moved certificate auth from location to server, but I'm not sure how we can deal with this if a user specify 2 ingress to the same host. 

Ex: 
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: xxxx
  annotations:
    ingress.kubernetes.io/auth-tls-secret: "default/caingress" 
spec:
  rules:
  - host: monitoring.domain.tld
    http:
      paths:
      - path: /bla
        backend:
          serviceName:default-backend
          servicePort: 80
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: xxxx
  annotations:
    ingress.kubernetes.io/auth-tls-secret: "custom/anothertls" 
spec:
  rules:
  - host: monitoring.domain.tld
    http:
      paths:
      - path: /
        backend:
          serviceName:default-backend
          servicePort: 80
```

@aledbf, @durrheimer, @rikatz wdyt guys? Validate if ingress has 2 auth-tls-secret: for the same domain or just go ahed?