### PR TITLE
Fixing wildcard in hostname for the upstream map

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -479,6 +479,7 @@ stream {
     {{ if gt (len $passthroughBackends) 0 }}
     # map FQDN that requires SSL passthrough
     map $ssl_preread_server_name $stream_upstream {
+        hostnames;
         {{ range $i, $passthrough := .PassthroughBackends }}
         {{ $passthrough.Hostname }}         {{  $passthrough.Backend }};
         {{ end }}


### PR DESCRIPTION
Our team came across the issue that wildcard hostnames would go to the default backend and ignore our ingress rule for that wildcard. After some searching it became clear that the upstream map where the ssl_preread_server_name did not map on our *.test.com domain. In the nginx documentation (http://nginx.org/en/docs/http/ngx_http_map_module.html) they refer to the ```hostnames;``` rule where you allow source values with pre and suffixes.