### PR TITLE
Track default SSL cert if TLS.SecretName is empty

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -1094,7 +1094,12 @@ func (ic GenericController) extractSecretNames(ing *extensions.Ingress) {
 	}
 
 	for _, tls := range ing.Spec.TLS {
-		key := fmt.Sprintf("%v/%v", ing.Namespace, tls.SecretName)
+		var key string
+		if tls.SecretName == "" {
+			key = ic.cfg.DefaultSSLCertificate
+		} else {
+			key = fmt.Sprintf("%v/%v", ing.Namespace, tls.SecretName)
+		}
 		_, exists := ic.secretTracker.Get(key)
 		if !exists {
 			ic.secretTracker.Add(key, key)


### PR DESCRIPTION
This PR fixes `secret not found` warning and correctly track default SSL cert if Ingress' `TLS.SecretName` is empty.