### PR TITLE
Access VTS when using proxy_protocol

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -474,9 +474,9 @@ http {
         }
     }
     
-    {{- if $cfg.enableVtsStatus }}
+    {{- if $cfg.EnableVtsStatus }}
       server {
-           listen 18081 {{ if $cfg.useProxyProtocol -}} proxy_protocol {{ end -}} reuseport;
+           listen 18081 {{ if $cfg.UseProxyProtocol -}} proxy_protocol {{ end -}} reuseport;
             
             location /nginx_status {
                   proxy_pass http://127.0.0.1:18080;

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -473,6 +473,16 @@ http {
             {{ end }}
         }
     }
+    
+    {{- if $cfg.enableVtsStatus }}
+      server {
+           listen 18081 {{ if $cfg.useProxyProtocol -}} proxy_protocol {{ end -}} reuseport;
+            
+            location /nginx_status {
+                  proxy_pass http://127.0.0.1:18080;
+                }
+            }
+         {{ end -}}
 }
 
 stream {


### PR DESCRIPTION
When I activate proxy_protocol in version 0.8.3 I can not see the vts-status page, add a server to create a proxy to the original, so I can activate the proxy_protocol and see the VTS statistics; Maybe it's not the best solution but it works.
Do not add the proxy_protocol conditional on server 18080 because if enabled the / healthz path does not work for K8S.

Thanks in advance