### PR TITLE
Compute server_names_hash_bucket_size correctly

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx_test.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestNginxHashBucketSize(t *testing.T) {
+	tests := []struct {
+		n        int
+		expected int
+	}{
+		{0, 32},
+		{1, 32},
+		{2, 32},
+		{3, 32},
+		// ...
+		{13, 32},
+		{14, 32},
+		{15, 64},
+		{16, 64},
+		// ...
+		{45, 64},
+		{46, 64},
+		{47, 128},
+		{48, 128},
+		// ...
+		// ...
+		{109, 128},
+		{110, 128},
+		{111, 256},
+		{112, 256},
+		// ...
+		{237, 256},
+		{238, 256},
+		{239, 512},
+		{240, 512},
+	}
+
+	for _, test := range tests {
+		actual := nginxHashBucketSize(test.n)
+		if actual != test.expected {
+			t.Errorf("Test nginxHashBucketSize(%d): expected %d but returned %d", test.n, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
There were some edge cases where we did not calculate hash_bucket_size
correctly.

Fix #623