### PR TITLE
Add support for services of type ExternalName

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -1007,12 +1007,6 @@ func (ic *GenericController) getEndpoints(
 	servicePort intstr.IntOrString,
 	proto api.Protocol,
 	hz *healthcheck.Upstream) []ingress.Endpoint {
-	glog.V(3).Infof("getting endpoints for service %v/%v and port %v", s.Namespace, s.Name, servicePort.String())
-	ep, err := ic.endpLister.GetServiceEndpoints(s)
-	if err != nil {
-		glog.Warningf("unexpected error obtaining service endpoints: %v", err)
-		return []ingress.Endpoint{}
-	}
 
 	upsServers := []ingress.Endpoint{}
 
@@ -1020,6 +1014,53 @@ func (ic *GenericController) getEndpoints(
 	// contains multiple port definitions sharing the same
 	// targetport.
 	adus := make(map[string]bool, 0)
+
+	// ExternalName services
+	if s.Spec.Type == api.ServiceTypeExternalName {
+		var targetPort int
+
+		switch servicePort.Type {
+		case intstr.Int:
+			targetPort = servicePort.IntValue()
+		case intstr.String:
+			port, err := service.GetPortMapping(servicePort.StrVal, s)
+			if err == nil {
+				targetPort = int(port)
+				break
+			}
+
+			glog.Warningf("error mapping service port: %v", err)
+			err = ic.checkSvcForUpdate(s)
+			if err != nil {
+				glog.Warningf("error mapping service ports: %v", err)
+				return upsServers
+			}
+
+			port, err = service.GetPortMapping(servicePort.StrVal, s)
+			if err == nil {
+				targetPort = int(port)
+			}
+		}
+
+		// check for invalid port value
+		if targetPort <= 0 {
+			return upsServers
+		}
+
+		return append(upsServers, ingress.Endpoint{
+			Address:     s.Spec.ExternalName,
+			Port:        fmt.Sprintf("%v", targetPort),
+			MaxFails:    hz.MaxFails,
+			FailTimeout: hz.FailTimeout,
+		})
+	}
+
+	glog.V(3).Infof("getting endpoints for service %v/%v and port %v", s.Namespace, s.Name, servicePort.String())
+	ep, err := ic.endpLister.GetServiceEndpoints(s)
+	if err != nil {
+		glog.Warningf("unexpected error obtaining service endpoints: %v", err)
+		return upsServers
+	}
 
 	for _, ss := range ep.Subsets {
 		for _, epPort := range ss.Ports {


### PR DESCRIPTION
fixes #621

```yaml
kind: Service
apiVersion: v1
metadata:
  name: proxy-google-cl
spec:
  ports:
  - protocol: TCP
    port: 80
    targetPort: 80
  type: ExternalName
  externalName: www.google.cl

---

apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: proxy-to-google
  annotations:
    ingress.kubernetes.io/configuration-snippet: |
      # we cannot pass Host header
      set $best_http_host "";
      proxy_set_header Host                   $best_http_host;

spec:
  rules:
  - host: foo.bar
    http:
      paths:
      - path: /
        backend:
          serviceName: proxy-google-cl
          servicePort: 80
```

```console
$ kubectl exec -n kube-system nginx-ingress-controller-605381865-1zqg3 -- curl http://localhost -H 'Host: foo.bar' -v
* Rebuilt URL to: http://localhost/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: foo.bar
> User-Agent: curl/7.47.0
> Accept: */*
>
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>302 Moved</TITLE></HEAD><BODY>
<H1>302 Moved</H1>
The document has moved
<A HREF="http://www.google.cl/?gfe_rd=cr&amp;ei=9hz4WJB_haHGBIqjj-AM">here</A>.
</BODY></HTML>
< HTTP/1.1 302 Found
< Server: nginx/1.11.12
< Date: Thu, 20 Apr 2017 02:29:10 GMT
< Content-Type: text/html; charset=UTF-8
< Content-Length: 256
< Connection: keep-alive
< Cache-Control: private
< Referrer-Policy: no-referrer
< Location: http://www.google.cl/?gfe_rd=cr&ei=9hz4WJB_haHGBIqjj-AM
<
{ [256 bytes data]
100   256  100   256    0     0   4241      0 --:--:-- --:--:-- --:--:--  4266
* Connection #0 to host localhost left intact
```