### PR TITLE
Configuration snippets documentation improvements

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -48,6 +48,7 @@ The following annotations are supported:
 |[ingress.kubernetes.io/auth-url](#external-authentication)|string|
 |[ingress.kubernetes.io/auth-tls-secret](#certificate-authentication)|string|
 |[ingress.kubernetes.io/auth-tls-verify-depth](#certificate-authentication)|number|
+|[ingress.kubernetes.io/configuration-snippet](#configuration-snippet)|string|
 |[ingress.kubernetes.io/enable-cors](#enable-cors)|true or false|
 |[ingress.kubernetes.io/force-ssl-redirect](#server-side-https-enforcement-through-redirect)|true or false|
 |[ingress.kubernetes.io/limit-connections](#rate-limiting)|number|
@@ -151,6 +152,14 @@ The validation depth between the provided client certificate and the Certificati
 
 Please check the [tls-auth](/examples/auth/client-certs/nginx/README.md) example.
 
+### Configuration snippet
+
+Using this annotion you can add additional configuration to the NGINX location. For example:
+
+```
+ingress.kubernetes.io/configuration-snippet: |
+  more_set_headers "Request-Id: $request_id";
+```
 
 ### Enable CORS
 

--- a/examples/customization/configuration-snippets/nginx/README.md
+++ b/examples/customization/configuration-snippets/nginx/README.md
@@ -38,7 +38,15 @@ default-http-backend-2657704409-qgwdd      1/1       Running   0          2m
 nginx-ingress-controller-873061567-4n3k2   1/1       Running   0          42s
 ```
 
+## Ingress
+The Ingress in this example adds a custom header to Nginx configuration that only applies to that specific Ingress. If you want to add headers that apply globally to all Ingresses, please have a look at [this example](/examples/customization/custom-headers/nginx).
+
+```console
+$ kubectl apply -f ingress.yaml
+deployment "nginx-ingress-controller" created
+```
+
 ## Test
 
-Check the contents of the annotation is present in the nginx.conf file using:
+Check if the contents of the annotation are present in the nginx.conf file using:
 `kubectl exec nginx-ingress-controller-873061567-4n3k2 -n kube-system cat /etc/nginx/nginx.conf`

--- a/examples/customization/configuration-snippets/nginx/README.md
+++ b/examples/customization/configuration-snippets/nginx/README.md
@@ -20,10 +20,6 @@ NAME                                    READY     STATUS    RESTARTS   AGE
 default-http-backend-2657704409-qgwdd   1/1       Running   0          28s
 ```
 
-```console
-$ kubectl create -f nginx-load-balancer-conf.yaml
-```
-
 ## Controller
 
 You can deploy the controller as follows:

--- a/examples/customization/configuration-snippets/nginx/nginx-load-balancer-conf.yaml
+++ b/examples/customization/configuration-snippets/nginx/nginx-load-balancer-conf.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  proxy-set-headers: "kube-system/custom-headers"
-kind: ConfigMap
-metadata:
-  name: nginx-load-balancer-conf
-  namespace: kube-system


### PR DESCRIPTION
Configuration snippets annotation was missing from the Configuration documentation. Also the Configuration snippet example confused me a bit because it referenced a ConfigMap that included the `proxy-set-headers` property that allows for globally defined custom headers instead of custom headers specific to just one Ingress.