### PR TITLE
Fix default value information

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -468,7 +468,7 @@ The following table shows the options, the default value and a description.
 
 Support for websockets is provided by NGINX out of the box. No special configuration required.
 
-The only requirement to avoid the close of connections is the increase of the values of `proxy-read-timeout` and `proxy-send-timeout`. The default value of this settings is `30 seconds`.
+The only requirement to avoid the close of connections is the increase of the values of `proxy-read-timeout` and `proxy-send-timeout`. The default value of this settings is `60 seconds`.
 A more adequate value to support websockets is a value higher than one hour (`3600`).
 
 


### PR DESCRIPTION
proxy-read-timeout and proxy-send-timeout default value is 60 seconds, not 30.