### PR TITLE
Update README.md

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -295,7 +295,7 @@ data:
 ```
 
 
-Please check the [tcp services](examples/tcp/README.md) example
+Please check the [tcp services](../../examples/tcp/nginx/README.md) example
 
 ## Exposing UDP services
 


### PR DESCRIPTION
fixed tcp services example link.

note: udp services link is also broken, I don't know correct link path.