### PR TITLE
[GLBC] Specify balancing mode for backends being added to existing backend service

### DIFF
--- a/controllers/gce/backends/backends.go
+++ b/controllers/gce/backends/backends.go
@@ -338,7 +338,7 @@ func (b *Backends) edgeHop(be *compute.BackendService, igs []*compute.InstanceGr
 	if beIGs.IsSuperset(igLinks) {
 		return nil
 	}
-	glog.Infof("Backend %v has a broken edge, expected igs %+v, current igs %+v",
+	glog.V(2).Infof("Backend %v has a broken edge, expected igs %+v, current igs %+v",
 		be.Name, igLinks.List(), beIGs.List())
 
 	originalBackends := be.Backends
@@ -356,15 +356,16 @@ func (b *Backends) edgeHop(be *compute.BackendService, igs []*compute.InstanceGr
 
 		if err := b.cloud.UpdateBackendService(be); err != nil {
 			if utils.IsHTTPErrorCode(err, http.StatusBadRequest) {
-				glog.Infof("Error updating backend service backends with balancing mode %v:%v", bm, err)
+				glog.V(2).Infof("Updating backend service backends with balancing mode %v failed, will try another mode. err:%v", bm, err)
 				errs = append(errs, err.Error())
 				continue
 			}
+			glog.V(2).Infof("Error updating backend service backends with balancing mode %v:%v", bm, err)
 			return err
 		}
 		return nil
 	}
-	return fmt.Errorf("%v", strings.Join(errs, "\n"))
+	return fmt.Errorf("received errors when updating backend service: %v", strings.Join(errs, "\n"))
 }
 
 // Sync syncs backend services corresponding to ports in the given list.

--- a/controllers/gce/backends/backends.go
+++ b/controllers/gce/backends/backends.go
@@ -209,7 +209,7 @@ func (b *Backends) Add(p ServicePort) error {
 	pName := b.namer.BeName(p.Port)
 	be, _ = b.Get(p.Port)
 	if be == nil {
-		glog.V(2).Infof("Creating backend for %d instance groups, port %v named port %v", len(igs), p.Port, namedPort)
+		glog.V(2).Infof("Creating backend service for port %v named port %v", p.Port, namedPort)
 		be, err = b.create(namedPort, hcLink, p.Protocol, pName)
 		if err != nil {
 			return err
@@ -315,8 +315,8 @@ func (b *Backends) edgeHop(be *compute.BackendService, igs []*compute.InstanceGr
 	if beIGs.IsSuperset(igLinks) {
 		return nil
 	}
-	glog.V(2).Infof("Backend service %v has missing backends, expected igs %+v, current igs %+v",
-		be.Name, igLinks.List(), beIGs.List())
+	glog.V(2).Infof("Updating backend service %v with %d backends: expected igs %+v, current igs %+v",
+		be.Name, igLinks.Len(), igLinks.List(), beIGs.List())
 
 	originalBackends := be.Backends
 	var addIGs []*compute.InstanceGroup

--- a/controllers/gce/backends/fakes.go
+++ b/controllers/gce/backends/fakes.go
@@ -99,6 +99,11 @@ func (f *FakeBackendServices) ListBackendServices() (*compute.BackendServiceList
 
 // UpdateBackendService fakes updating a backend service.
 func (f *FakeBackendServices) UpdateBackendService(be *compute.BackendService) error {
+	if f.errFunc != nil {
+		if err := f.errFunc(utils.Update, be); err != nil {
+			return err
+		}
+	}
 	f.calls = append(f.calls, utils.Update)
 	return f.backendServices.Update(be)
 }


### PR DESCRIPTION
Related to https://github.com/kubernetes/ingress/pull/251 This was a noticeable issue for federated ingress, but could happen for any cluster which adds a new zone of nodes with an existing ingress. Since the backend service already exists in these cases, the controller will attempt to add backends to the existing backend service resource. However, the balancing mode was not being specified and defaulting to UTILIZATION.  If there are existing backend services of type RATE pointing to the same instance groups, the backend-service update will fail. 

New Behavior:
 - Creation of backend-service does NOT include a list of backends. It's only responsible for setting protocol, name, and health check correctly.
 - `edgeHop` now is responsible for adding sets of backends to the backend-service. It has the same RATE-then-UTILIZATION fallback logic as the backend-service creation func had.

The controller has always and will continue to assume that all instance-groups (zones) in a region use the same balancing mode. If this convention isn't followed, it cannot update the set of backends for that cluster.