### PR TITLE
Fix error in generated nginx.conf for optional hsts-preload

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -240,7 +240,7 @@ http {
         {{ end }}
 
         {{ if (and (not (empty $server.SSLCertificate)) $cfg.HSTS) }}
-        more_set_headers                        "Strict-Transport-Security: max-age={{ $cfg.HSTSMaxAge }}{{ if $cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }}; {{ if $cfg.HSTSPreload }}preload{{ end }}";
+        more_set_headers                        "Strict-Transport-Security: max-age={{ $cfg.HSTSMaxAge }}{{ if $cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }};{{ if $cfg.HSTSPreload }} preload{{ end }}";
         {{ end }}
 
         {{ if $cfg.EnableVtsStatus }}vhost_traffic_status_filter_by_set_key $geoip_country_code country::$server_name;{{ end }}


### PR DESCRIPTION
With PR #563 a trailing space is rendered in nginx.conf for optional HSTS preload option (false by default):

    more_set_headers                        "Strict-Transport-Security: max-age=15724800; includeSubDomains; ";

## Error

This brakes some clients, e.g. very popular HTTP2 [Python hyper-h2](https://github.com/python-hyper/hyper-h2) with:

    h2.exceptions.ProtocolError: Received header value surrounded by whitespace b'max-age=15724800; includeSubDomains; '

## Fix

This PR fixes the trailing space and moves it before the optional value as " preload".
