### PR TITLE
[nginx] pass non-SNI TLS hello to default backend, Fixes #693

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -83,7 +83,13 @@ func newNGINXController() ingress.Controller {
 		configmap:     &api_v1.ConfigMap{},
 		isIPV6Enabled: isIPv6Enabled(),
 		resolver:      h,
-		proxy:         &proxy{},
+		proxy: &proxy{
+			Default: &server{
+				Hostname: "localhost",
+				IP:       "127.0.0.1",
+				Port:     442,
+			},
+		},
 	}
 
 	listener, err := net.Listen("tcp", ":443")

--- a/controllers/nginx/pkg/cmd/controller/tcp.go
+++ b/controllers/nginx/pkg/cmd/controller/tcp.go
@@ -27,11 +27,7 @@ func (p *proxy) Get(host string) *server {
 		}
 	}
 
-	return &server{
-		Hostname: "localhost",
-		IP:       "127.0.0.1",
-		Port:     442,
-	}
+	return p.Default
 }
 
 func (p *proxy) Handle(conn net.Conn) {


### PR DESCRIPTION
tested with image pushed to quay.io/donaldguy/nginx-ingress-controller:no-sni

Just verified that sites still load and that `openssl s_client` now works
w/ AND w/o a servername.

Fixes #693 