### PR TITLE
Adding support for externalIP Services

### DIFF
--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -126,13 +126,16 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		}
 
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
-			// We could poll here, but we instead just exit and rely on k8s to restart us
-			glog.Fatalf("service %s does not (yet) have ingress points", *publishSvc)
+			if len(svc.Spec.ExternalIPs) > 0 {
+				glog.Infof("service %v validated as assigned with externalIP", *publishSvc)
+			} else {
+				// We could poll here, but we instead just exit and rely on k8s to restart us
+				glog.Fatalf("service %s does not (yet) have ingress points", *publishSvc)
+			}
+		} else {
+			glog.Infof("service %v validated as source of Ingress status", *publishSvc)
 		}
-
-		glog.Infof("service %v validated as source of Ingress status", *publishSvc)
 	}
-
 	if *watchNamespace != "" {
 
 		_, err = k8s.IsValidNamespace(kubeClient, *watchNamespace)

--- a/core/pkg/ingress/status/status.go
+++ b/core/pkg/ingress/status/status.go
@@ -223,6 +223,9 @@ func (s *statusSync) runningAddresess() ([]string, error) {
 				addrs = append(addrs, ip.IP)
 			}
 		}
+		for _, ip := range svc.Spec.ExternalIPs {
+			addrs = append(addrs, ip)
+		}
 
 		return addrs, nil
 	}


### PR DESCRIPTION
Since hostPort is broken on CNI (https://github.com/kubernetes/kubernetes/issues/31307) and I don't want to expose the nginx controller to my host network, I created a service with an external IP configuration. I tried to run it like the AWS LoadBalancer Example (https://github.com/kubernetes/ingress/tree/master/examples/aws/nginx), but it failed since the service's status didn't advertise any ingress IPs. I fixed that to check for external IPs in the service to and tracked down the usage of the services ingress IP (core/pkg/ingress/status/status.go) and added the external IPs there to.

My configuration now looks like this:
```
kind: Service
apiVersion: v1
metadata:
  name: nginx-default-backend
  namespace: kube-system
  labels:
    k8s-addon: ingress-nginx.addons.k8s.io
spec:
  ports:
  - port: 80
    targetPort: http
  selector:
    app: nginx-default-backend

---

kind: Deployment
apiVersion: extensions/v1beta1
metadata:
  name: nginx-default-backend
  namespace: kube-system
  labels:
    k8s-addon: ingress-nginx.addons.k8s.io
spec:
  replicas: 1
  template:
    metadata:
      labels:
        k8s-addon: ingress-nginx.addons.k8s.io
        app: nginx-default-backend
    spec:
      terminationGracePeriodSeconds: 60
      containers:
      - name: default-http-backend
        image: gcr.io/google_containers/defaultbackend:1.0
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 30
          timeoutSeconds: 5
        resources:
          limits:
            cpu: 10m
            memory: 20Mi
          requests:
            cpu: 10m
            memory: 20Mi
        ports:
        - name: http
          containerPort: 8080
          protocol: TCP

---

kind: Service
apiVersion: v1
metadata:
  name: nginx-ingress-controller
  namespace: kube-system
spec:
  selector:
    k8s-app: nginx-ingress-controller
  ports:
    - name: http
      port: 80
      targetPort: 80
    - name: https
      port: 443
      targetPort: 443
  externalIPs:
    - yourIPComesHere

---

apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: nginx-ingress-controller
  labels:
    k8s-app: nginx-ingress-controller
  namespace: kube-system
spec:
  replicas: 1
  template:
    metadata:
      labels:
        k8s-app: nginx-ingress-controller
    spec:
      terminationGracePeriodSeconds: 60
      containers:
      - image: lead4good/nginx-ingress-controller
        name: nginx-ingress-controller
        imagePullPolicy: Always
        readinessProbe:
          httpGet:
            path: /healthz
            port: 10254
            scheme: HTTP
        livenessProbe:
          httpGet:
            path: /healthz
            port: 10254
            scheme: HTTP
          initialDelaySeconds: 10
          timeoutSeconds: 1
        ports:
        - containerPort: 80
        - containerPort: 443
        env:
          - name: POD_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
        args:
        - /nginx-ingress-controller
        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
        - --publish-service=$(POD_NAMESPACE)/nginx-ingress-controller
```

Once this pull request is accepted, I will add an usage example, too.