### PR TITLE
fix nginx reload flags '-c'

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -249,7 +249,7 @@ func (n NGINXController) Reload(data []byte) ([]byte, bool, error) {
 		return nil, false, err
 	}
 
-	o, e := exec.Command(n.binary, "-s", "reload").CombinedOutput()
+	o, e := exec.Command(n.binary, "-s", "reload", "-c", cfgPath).CombinedOutput()
 
 	return o, true, e
 }


### PR DESCRIPTION
add nginx reload flags -c ,  
then , will allow yourself to compile the nginx version

go fmt this file
