### PR TITLE
Add config for X-Forwarded-For trust

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -23,8 +23,8 @@ http {
     set_real_ip_from    {{ $cfg.ProxyRealIPCIDR }};
     real_ip_header      proxy_protocol;
     {{ else }}
+    set_real_ip_from    {{ $cfg.ProxyRealIPCIDR }};
     real_ip_header      X-Forwarded-For;
-    set_real_ip_from    0.0.0.0/0;
     {{ end }}
 
     real_ip_recursive   on;


### PR DESCRIPTION
Use the same config option for `set_real_ip_from` when not using proxy protocol. The default remains `0.0.0.0/0`, which is insecure if the ingress is publicly accessible (or its upstream doesn't strip the X-Forwarded-For header). This at least provides a workaround for #200