### PR TITLE
Set $proxy_upstream_name before location directive

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -241,6 +241,7 @@ http {
         server_name {{ $server.Hostname }};
         listen 80{{ if $cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $backlogSize }}{{end}};
         {{ if $IsIPV6Enabled }}listen [::]:80{{ if $cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $backlogSize }}{{ end }};{{ end }}
+        set $proxy_upstream_name "-";
 
         {{/* Listen on 442 because port 443 is used in the TLS sni server */}}
         {{/* This listener must always have proxy_protocol enabled, because the SNI listener forwards on source IP info in it. */}}
@@ -443,6 +444,7 @@ http {
         # https://github.com/kubernetes/contrib/blob/master/ingress/controllers/nginx/nginx/command.go#L104
         listen 18080 default_server reuseport backlog={{ .BacklogSize }};
         {{ if $IsIPV6Enabled }}listen [::]:18080 default_server reuseport backlog={{ .BacklogSize }};{{ end }}
+        set $proxy_upstream_name "-";
 
         location {{ $healthzURI }} {
             access_log off;


### PR DESCRIPTION
When nginx performs ssl redirect, $proxy_upstream_name used in log
is not initialized because it is set after nginx matched a location directive,
which is not the case when performing a ssl redirect.

refs #711