### PR TITLE
Corrected annotation ex `signin-url` to `auth-url`

### DIFF
--- a/examples/external-auth/nginx/README.md
+++ b/examples/external-auth/nginx/README.md
@@ -24,7 +24,7 @@ metadata:
   name: application
   annotations:
     "ingress.kubernetes.io/auth-url": "https://$host/oauth2/auth"
-    "ingress.kubernetes.io/signin-url": "https://$host/oauth2/sign_in"
+    "ingress.kubernetes.io/auth-signin": "https://$host/oauth2/sign_in"
 ...
 ```
 


### PR DESCRIPTION
Example was wrong, had to dig through code to find the correct annotation.

