### PR TITLE
Add secure-verify-ca-secret annotation

### DIFF
--- a/core/pkg/ingress/controller/annotations.go
+++ b/core/pkg/ingress/controller/annotations.go
@@ -68,7 +68,7 @@ func newAnnotationExtractor(cfg extractorConfig) annotationExtractor {
 			"Proxy":                proxy.NewParser(cfg),
 			"RateLimit":            ratelimit.NewParser(),
 			"Redirect":             rewrite.NewParser(cfg),
-			"SecureUpstream":       secureupstream.NewParser(),
+			"SecureUpstream":       secureupstream.NewParser(cfg),
 			"SessionAffinity":      sessionaffinity.NewParser(),
 			"SSLPassthrough":       sslpassthrough.NewParser(),
 			"ConfigurationSnippet": snippet.NewParser(),
@@ -111,9 +111,13 @@ const (
 	sessionAffinity = "SessionAffinity"
 )
 
-func (e *annotationExtractor) SecureUpstream(ing *extensions.Ingress) bool {
-	val, _ := e.annotations[secureUpstream].Parse(ing)
-	return val.(bool)
+func (e *annotationExtractor) SecureUpstream(ing *extensions.Ingress) *secureupstream.Secure {
+	val, err := e.annotations[secureUpstream].Parse(ing)
+	if err != nil {
+		glog.Errorf("error parsing secure upstream: %v", err)
+	}
+	secure := val.(*secureupstream.Secure)
+	return secure
 }
 
 func (e *annotationExtractor) HealthCheck(ing *extensions.Ingress) *healthcheck.Upstream {

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -783,7 +783,10 @@ func (ic *GenericController) createUpstreams(data []interface{}) map[string]*ing
 				glog.V(3).Infof("creating upstream %v", name)
 				upstreams[name] = newUpstream(name)
 				if !upstreams[name].Secure {
-					upstreams[name].Secure = secUpstream
+					upstreams[name].Secure = secUpstream.Secure
+				}
+				if upstreams[name].SecureCACert.Secret == "" {
+					upstreams[name].SecureCACert = secUpstream.CACert
 				}
 				if upstreams[name].SessionAffinity.AffinityType == "" {
 					upstreams[name].SessionAffinity.AffinityType = affinity.AffinityType

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/annotations/ratelimit"
 	"k8s.io/ingress/core/pkg/ingress/annotations/rewrite"
 	"k8s.io/ingress/core/pkg/ingress/defaults"
+	"k8s.io/ingress/core/pkg/ingress/resolver"
 	"k8s.io/ingress/core/pkg/ingress/store"
 )
 
@@ -154,8 +155,10 @@ type Backend struct {
 	// Allowing the use of HTTPS
 	// The endpoint/s must provide a TLS connection.
 	// The certificate used in the endpoint cannot be a self signed certificate
-	// TODO: add annotation to allow the load of ca certificate
 	Secure bool `json:"secure"`
+	// SecureCACert has the filename and SHA1 of the certificate authorities used to validate
+	// a secured connection to the backend
+	SecureCACert resolver.AuthSSLCert `json:"secureCert"`
 	// SSLPassthrough indicates that Ingress controller will delegate TLS termination to the endpoints.
 	SSLPassthrough bool `json:"sslPassthrough"`
 	// Endpoints contains the list of endpoints currently running


### PR DESCRIPTION
Add `ingress.kubernetes.io/secure-verify-ca-secret` annotation and a new `types.Backend.SecureCACert` field without changing previous behaviour.