### PR TITLE
POC: Setting upstream vhost for nginx.

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -698,7 +698,13 @@ stream {
             client_body_buffer_size                 {{ $location.ClientBodyBufferSize }};
             {{ end }}
 
+            {{/* By default use vhost as Host to upstream, but allow overrides */}}
+            {{ if not (empty $location.UpstreamVhost) }}
+            proxy_set_header Host                   "{{ $location.UpstreamVhost }}";
+            {{ else }}
             proxy_set_header Host                   $best_http_host;
+            {{ end }}
+
 
             # Pass the extracted client certificate to the backend
             {{ if not (empty $server.CertificateAuth.CAFileName) }}

--- a/core/pkg/ingress/annotations/upstreamvhost/main.go
+++ b/core/pkg/ingress/annotations/upstreamvhost/main.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upstreamvhost
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+
+	"k8s.io/ingress/core/pkg/ingress/annotations/parser"
+)
+
+const (
+	annotation = "ingress.kubernetes.io/upstream-vhost"
+)
+
+type upstreamVhost struct {
+}
+
+// NewParser creates a new upstream VHost annotation parser
+func NewParser() parser.IngressAnnotation {
+	return upstreamVhost{}
+}
+
+// Parse parses the annotations contained in the ingress rule
+// used to indicate if the location/s contains a fragment of
+// configuration to be included inside the paths of the rules
+func (a upstreamVhost) Parse(ing *extensions.Ingress) (interface{}, error) {
+	return parser.GetStringAnnotation(annotation, ing)
+}

--- a/core/pkg/ingress/controller/annotations.go
+++ b/core/pkg/ingress/controller/annotations.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/annotations/sessionaffinity"
 	"k8s.io/ingress/core/pkg/ingress/annotations/snippet"
 	"k8s.io/ingress/core/pkg/ingress/annotations/sslpassthrough"
+	"k8s.io/ingress/core/pkg/ingress/annotations/upstreamvhost"
 	"k8s.io/ingress/core/pkg/ingress/errors"
 	"k8s.io/ingress/core/pkg/ingress/resolver"
 )
@@ -78,6 +79,7 @@ func newAnnotationExtractor(cfg extractorConfig) annotationExtractor {
 			"Alias":                alias.NewParser(),
 			"ClientBodyBufferSize": clientbodybuffersize.NewParser(),
 			"DefaultBackend":       defaultbackend.NewParser(cfg),
+			"UpstreamVhost":        upstreamvhost.NewParser(),
 		},
 	}
 }

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -273,6 +273,10 @@ type Location struct {
 	Service *api.Service `json:"service,omitempty"`
 	// Port describes to which port from the service
 	Port intstr.IntOrString `json:"port"`
+	// Overwrite the Host header passed into the backend. Defaults to
+	// vhost of the incoming request.
+	// +optional
+	UpstreamVhost string `json:"upstream-vhost"`
 	// BasicDigestAuth returns authentication configuration for
 	// an Ingress rule.
 	// +optional


### PR DESCRIPTION
In the current k8 ingress there's no way to control "Host" header sent to upstream server; it's always the configured vhost.

It's desirable to support custom Host header when proxying for a number of cases. One such case is forwarding to an Service that points to an external host that expect a host paramater (like AWS S3 buckets). There's a number of others.

By default nginx set Host to the upstreams domain name (and not the one passed in) like K8 always forces. This provided an escape hatch to this behavior.

This is a proof of concept PR for review, feedback. I can incorporate all of that; I just need to make sure I'm going down the right path.