### PR TITLE
change the directory of default-backend.yaml

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -55,7 +55,7 @@ $ ./nginx-ingress-controller --running-in-cluster=false --default-backend-servic
 
 First create a default backend:
 ```
-$ kubectl create -f examples/default-backend.yaml
+$ kubectl create -f examples/deployment/nginx/default-backend.yaml
 $ kubectl expose rc default-http-backend --port=80 --target-port=8080 --name=default-http-backend
 ```
 


### PR DESCRIPTION
there is no default-backend.yaml in examples directory,so we should change the doc. 