### PR TITLE
Add support for add_headers

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -479,6 +479,18 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 		}
 	}
 
+	addHeaders := map[string]string{}
+	if cfg.AddHeaders != "" {
+		cmap, exists, err := n.storeLister.ConfigMap.GetByKey(cfg.AddHeaders)
+		if err != nil {
+			glog.Warningf("unexpected error reading configmap %v: %v", cfg.AddHeaders, err)
+		}
+
+		if exists {
+			addHeaders = cmap.(*api_v1.ConfigMap).Data
+		}
+	}
+
 	sslDHParam := ""
 	if cfg.SSLDHParam != "" {
 		secretName := cfg.SSLDHParam
@@ -507,6 +519,7 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 
 	content, err := n.t.Write(config.TemplateConfig{
 		ProxySetHeaders:     setHeaders,
+		AddHeaders:          addHeaders,
 		MaxOpenFiles:        maxOpenFiles,
 		BacklogSize:         sysctlSomaxconn(),
 		Backends:            ingressCfg.Backends,

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -83,6 +83,9 @@ const (
 type Configuration struct {
 	defaults.Backend `json:",squash"`
 
+	// Sets the name of the configmap that contains the headers to pass to the client
+	AddHeaders string `json:"add-headers,omitempty"`
+
 	// AllowBackendServerHeader enables the return of the header Server from the backend
 	// instead of the generic nginx string.
 	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header
@@ -368,7 +371,7 @@ func NewDefault() Configuration {
 			SkipAccessLogURLs:    []string{},
 		},
 		UpstreamKeepaliveConnections: 0,
-		LimitConnZoneVariable: defaultLimitConnZoneVariable,
+		LimitConnZoneVariable:        defaultLimitConnZoneVariable,
 	}
 
 	if glog.V(5) {
@@ -392,6 +395,7 @@ func (cfg Configuration) BuildLogFormatUpstream() string {
 // TemplateConfig contains the nginx configuration to render the file nginx.conf
 type TemplateConfig struct {
 	ProxySetHeaders     map[string]string
+	AddHeaders          map[string]string
 	MaxOpenFiles        int
 	BacklogSize         int
 	Backends            []*ingress.Backend

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -3,6 +3,7 @@
 {{ $healthzURI := .HealthzURI }}
 {{ $backends := .Backends }}
 {{ $proxyHeaders := .ProxySetHeaders }}
+{{ $addHeaders := .AddHeaders }}
 daemon off;
 
 worker_processes {{ $cfg.WorkerProcesses }};
@@ -90,6 +91,11 @@ http {
     gzip_min_length 256;
     gzip_types {{ $cfg.GzipTypes }};
     gzip_proxied any;
+    {{ end }}
+
+    # Custom headers for response
+    {{ range $k, $v := $addHeaders }}
+    add_header {{ $k }}            "{{ $v }}";
     {{ end }}
 
     server_tokens {{ if $cfg.ShowServerTokens }}on{{ else }}off{{ end }};
@@ -324,6 +330,7 @@ http {
             return 302 {{ $location.Redirect.AppRoot }};
         }
         {{ end }}
+
         {{ if not (empty $authPath) }}
         location = {{ $authPath }} {
             internal;
@@ -427,7 +434,7 @@ http {
             # https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
             proxy_set_header Proxy                  "";
 
-            # Custom headers
+            # Custom headers to proxied server
             {{ range $k, $v := $proxyHeaders }}
             proxy_set_header {{ $k }}                    "{{ $v }}";
             {{ end }}


### PR DESCRIPTION
Add support for [add_headers](http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header) globally. Uses similar pattern as custom proxy headers in https://github.com/kubernetes/ingress/pull/246 . 

Could be taken further by adding support for annotations and adding this per location, but global is what our usecase needs right now 