### PR TITLE
add zalando-incubator project kube-ingress-aws-controller to catalog

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -7,3 +7,4 @@ This is a non-comprehensive list of existing ingress controllers.
 * [Linkerd](https://linkerd.io/config/0.9.1/linkerd/index.html#ingress-identifier)
 * [traefik](https://docs.traefik.io/toml/#kubernetes-ingress-backend)
 * [AWS Application Load Balancer Ingress Controller](https://github.com/coreos/alb-ingress-controller)
+* [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller)


### PR DESCRIPTION
Add https://github.com/zalando-incubator/kube-ingress-aws-controller to the ingress catalog