### PR TITLE
Use DaemonSet for nginx kubeadm deployment example

### DIFF
--- a/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
@@ -51,14 +51,13 @@ spec:
     k8s-app: default-http-backend
 ---
 apiVersion: extensions/v1beta1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: nginx-ingress-controller
   labels:
     k8s-app: nginx-ingress-controller
   namespace: kube-system
 spec:
-  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
This is a much better default fit than a default deployment, since
you get to hit any node for it to work (rather than a deployment,
which could end up anywhere)