### PR TITLE
Add ConfigureFlags() on controller interface

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -314,6 +314,11 @@ func (n NGINXController) Info() *ingress.BackendInfo {
 	}
 }
 
+// ConfigureFlags allow to configure more flags before the parsing of
+// command line arguments
+func (n *NGINXController) ConfigureFlags(flags *pflag.FlagSet) {
+}
+
 // OverrideFlags customize NGINX controller flags
 func (n *NGINXController) OverrideFlags(flags *pflag.FlagSet) {
 	ic, _ := flags.GetString("ingress-class")

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -92,8 +92,8 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 	)
 
 	flags.AddGoFlagSet(flag.CommandLine)
+	backend.ConfigureFlags(flags)
 	flags.Parse(os.Args)
-
 	backend.OverrideFlags(flags)
 
 	flag.Set("logtostderr", "true")

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -94,6 +94,9 @@ type Controller interface {
 	BackendDefaults() defaults.Backend
 	// Info returns information about the ingress controller
 	Info() *BackendInfo
+	// ConfigureFlags allow to configure more flags before the parsing of
+	// command line arguments
+	ConfigureFlags(*pflag.FlagSet)
 	// OverrideFlags allow the customization of the flags in the backend
 	OverrideFlags(*pflag.FlagSet)
 	// DefaultIngressClass just return the default ingress class

--- a/examples/custom-controller/server.go
+++ b/examples/custom-controller/server.go
@@ -83,6 +83,9 @@ func (dc DummyController) Info() *ingress.BackendInfo {
 	}
 }
 
+func (n DummyController) ConfigureFlags(*pflag.FlagSet) {
+}
+
 func (n DummyController) OverrideFlags(*pflag.FlagSet) {
 }
 


### PR DESCRIPTION
`ConfigureFlags()` allow to include more command line options on an Ingress controller.