### PR TITLE
Correct the format of 'copyright'

### DIFF
--- a/examples/custom-controller/Dockerfile
+++ b/examples/custom-controller/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017[<0;55;12M The Kubernetes Authors. All rights reserved.
+# Copyright 2017 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/custom-controller/Makefile
+++ b/examples/custom-controller/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors All rights reserved.
+# Copyright 2017 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/custom-controller/server.go
+++ b/examples/custom-controller/server.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (


### PR DESCRIPTION
Hi, two things have been included: 
    1, correct the format of 'copyright' for some files;
     2, add copyright for server.go
thank you!