### PR TITLE
Fix README WRT. building nginx-ingress-controller

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -46,9 +46,9 @@ Anytime we reference a tls secret, we mean (x509, pem encoded, RSA 2048, etc). Y
 Before deploying the controller to production you might want to run it outside the cluster and observe it.
 
 ```console
-$ make controller
+$ make build
 $ mkdir /etc/nginx-ssl
-$ ./nginx-ingress-controller --running-in-cluster=false --default-backend-service=kube-system/default-http-backend
+$ ./rootfs/nginx-ingress-controller --running-in-cluster=false --default-backend-service=kube-system/default-http-backend
 ```
 
 ## Deployment


### PR DESCRIPTION
The nginx ingress controller README has erroneous instructions for building the controller binary and for how to run it. This PR rectifies the issues I've found.