### PR TITLE
Publish echoheader image

### DIFF
--- a/images/echoheaders/Dockerfile
+++ b/images/echoheaders/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google_containers/nginx-slim:0.17
+
+ADD nginx.conf /etc/nginx/nginx.conf
+ADD README.md README.md

--- a/images/echoheaders/Makefile
+++ b/images/echoheaders/Makefile
@@ -1,0 +1,11 @@
+all: push
+
+# TAG 0.0 shouldn't clobber any release builds
+TAG = 1.5
+PREFIX = gcr.io/google_containers/echoserver
+
+container:
+	docker build -t $(PREFIX):$(TAG) .
+
+push: container
+	gcloud docker -- push $(PREFIX):$(TAG)

--- a/images/echoheaders/README.md
+++ b/images/echoheaders/README.md
@@ -1,0 +1,8 @@
+# Echoserver
+
+This is a simple server that responds with the http headers it received.
+
+Image versions >= 1.4 removes the redirect introduced in 1.3.
+Image versions >= 1.3 redirect requests on :80 with `X-Forwarded-Proto: http` to :443.
+Image versions > 1.0 run an nginx server, and implement the echoserver using lua in the nginx config.
+Image versions <= 1.0 run a python http server instead of nginx, and don't redirect any requests.

--- a/images/echoheaders/echo-app.yaml
+++ b/images/echoheaders/echo-app.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoheaders
+  labels:
+    app: echoheaders
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: echoheaders
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: echoheaders
+  labels:
+    app: echoheaders
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: echoheaders
+    spec:
+      containers:
+      - name: echoheaders
+        image: gcr.io/google_containers/echoserver:1.5
+        ports:
+        - containerPort: 8080
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP

--- a/images/echoheaders/nginx.conf
+++ b/images/echoheaders/nginx.conf
@@ -1,0 +1,81 @@
+events {
+    worker_connections 1024;
+}
+
+env HOSTNAME;
+env NODE_NAME;
+env POD_NAME;
+env POD_NAMESPACE;
+env POD_IP;
+
+http {
+    default_type 'text/plain';
+    # maximum allowed size of the client request body. By default this is 1m.
+    # Request with bigger bodies nginx will return error code 413.
+    # http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+    client_max_body_size 10m;
+
+    server {
+        # please check the benefits of reuseport https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1
+        # basically instructs to create an individual listening socket for each worker process (using the SO_REUSEPORT
+        # socket option), allowing a kernel to distribute incoming connections between worker processes.
+        listen 8080 default_server reuseport;
+
+        # Replace '_' with your hostname.
+        server_name _;
+
+        location / {
+            lua_need_request_body on;
+            content_by_lua_block {
+                ngx.header["Server"] = "echoserver"
+
+                ngx.say("")
+                ngx.say("")
+                ngx.say("Hostname: ", os.getenv("HOSTNAME") or "N/A")
+                ngx.say("")
+
+                ngx.say("Pod Information:")
+                if os.getenv("POD_NAME") then
+                    ngx.say("\tnode name:\t ", os.getenv("NODE_NAME") or "N/A")
+                    ngx.say("\tpod name:\t ", os.getenv("POD_NAME") or "N/A")
+                    ngx.say("\tpod namespace:\t ", os.getenv("POD_NAMESPACE") or "N/A")
+                    ngx.say("\tpod IP:  \t ", os.getenv("POD_IP") or "N/A")
+                else
+                    ngx.say("\t-no pod information available-")
+                end
+
+                ngx.say("")
+
+                ngx.say("Server values:")
+                ngx.say("\tserver_version=", "nginx: "..ngx.var.nginx_version.." - lua: "..ngx.config.ngx_lua_version)
+                ngx.say("")
+
+                ngx.say("Request Information:")
+                ngx.say("\tclient_address=", ngx.var.remote_addr)
+                ngx.say("\tmethod=", ngx.req.get_method())
+                ngx.say("\treal path=", ngx.var.request_uri)
+                ngx.say("\tquery=", ngx.var.query_string or "")
+                ngx.say("\trequest_version=", ngx.req.http_version())
+                ngx.say("\trequest_uri=", ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri)
+                ngx.say("")
+
+                ngx.say("Request Headers:")
+                local headers = ngx.req.get_headers()
+                local keys = {}
+                for key, val in pairs(headers) do
+                    table.insert(keys, key)
+                end
+
+                table.sort(keys)
+                for i, key in ipairs(keys) do
+                    ngx.say("\t", key, "=", headers[key])
+                end
+                ngx.say("")
+
+                ngx.say("Request Body:")
+                ngx.say(ngx.var.request_body or "\t-no body in request-");
+                ngx.say("")
+            }
+        }
+    }
+}


### PR DESCRIPTION


This PR updates the echoheaders image to 1.5 adding information about the POD (if the env section is configured) and improves the output

```console
$ kubectl exec echoheaders-cgrxv curl localhost:8080

Hostname: echoheaders-cgrxv

Pod Information:
	node name:	 minikube
	pod name:	 echoheaders-cgrxv
	pod namespace:	 default
	pod IP:  	 172.17.0.8

Server values:
	server_version=nginx: 1.13.0 - lua: 10008

Request Information:
	client_address=127.0.0.1
	method=GET
	real path=/
	query=
	request_version=1.1
	request_uri=http://localhost:8080/

Request Headers:
	accept=*/*
	host=localhost:8080
	user-agent=curl/7.47.0

Request Body:
	-no body in request-
```