### PR TITLE
Add setting to allow returning the Server header from the backend

### DIFF
--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -82,6 +82,12 @@ const (
 type Configuration struct {
 	defaults.Backend `json:",squash"`
 
+	// AllowBackendServerHeader enables the return of the header Server from the backend
+	// instead of the generic nginx string.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header
+	// By default this is disabled
+	AllowBackendServerHeader bool `json:"allow-backend-server-header"`
+
 	// EnableDynamicTLSRecords enables dynamic TLS record sizes
 	// https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency
 	// By default this is enabled
@@ -280,6 +286,7 @@ type Configuration struct {
 // NewDefault returns the default nginx configuration
 func NewDefault() Configuration {
 	cfg := Configuration{
+		AllowBackendServerHeader:   false,
 		ClientHeaderBufferSize:     "1k",
 		ClientBodyBufferSize:       "8k",
 		EnableDynamicTLSRecords:    true,

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -216,6 +216,10 @@ http {
 
     proxy_ssl_session_reuse on;
 
+    {{ if $cfg.AllowBackendServerHeader }}
+    proxy_pass_header Server;
+    {{ end }}
+
     {{range $name, $upstream := $backends}}
     upstream {{$upstream.Name}} {
         {{ if eq $upstream.SessionAffinity.AffinityType "cookie" }}


### PR DESCRIPTION
fixes #782

```console
curl -v http://192.168.99.100 -k
* Rebuilt URL to: http://192.168.99.100/
*   Trying 192.168.99.100...
* TCP_NODELAY set
> GET / HTTP/1.1
> Host: 192.168.99.100
> User-Agent: curl/7.52.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Sun, 28 May 2017 21:46:50 GMT
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Connection: keep-alive
**< Server: echoserver** 
< Strict-Transport-Security: max-age=15724800; includeSubDomains;
< 


Hostname: echoheaders-vt1vr

Pod Information:
	node name:	 minikube
	pod name:	 echoheaders-vt1vr
	pod namespace:	 default
	pod IP:  	 172.17.0.8

Server values:
	server_version=nginx: 1.13.0 - lua: 10008

Request Information:
	client_address=172.17.0.4
	method=GET
	real path=/
	query=
	request_version=1.1
	request_uri=http://192.168.99.100:8080/

Request Headers:
	accept=*/*
	connection=close
	host=192.168.99.100
	user-agent=curl/7.52.1
	x-forwarded-for=192.168.99.1
	x-forwarded-host=192.168.99.100
	x-forwarded-port=443
	x-forwarded-proto=https
	x-original-uri=/
	x-real-ip=192.168.99.1192.168.99.1
	x-scheme=https

Request Body:
	-no body in request-

* Curl_http_done: called premature == 0
* Connection #0 to host 192.168.99.100 left intact
```