### PR TITLE
#789 removing duplicate X-Real-IP header 

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -386,9 +386,6 @@ http {
             proxy_set_header ssl-client-cert        $ssl_client_cert;
             {{ end }}
 
-            # Pass Real IP
-            proxy_set_header X-Real-IP              $the_real_ip;
-
             # Allow websocket connections
             proxy_set_header                        Upgrade           $http_upgrade;
             proxy_set_header                        Connection        $connection_upgrade;


### PR DESCRIPTION
Commit 4bd4bf3be65eb13166771d375991ccccc3fff664 added setting the X-Real-IP header, which was already added a few lines above. Removing the original `proxy_set_header X-Real-IP` because the newer one is better grouped with related `proxy_set_header` commands