### PR TITLE
Fix #798 - RBAC for leader election

### DIFF
--- a/examples/rbac/nginx/README.md
+++ b/examples/rbac/nginx/README.md
@@ -49,6 +49,21 @@ permissions are granted to the Role named `nginx-ingress-role`
 * `configmaps`, `pods`, `secrets`: get
 * `endpoints`: create, get, update
 
+Furthermore to support leader-election, the nginx-ingress-controller needs to
+have access to a `configmap` using the resourceName `ingress-controller-leader-nginx`
+
+* `configmaps`: create, get, update (for resourceName `ingress-controller-leader-nginx`)
+
+This resourceName is the concatenation of the `election-id` and the
+`ingress-class` as defined by the ingress-controller, which default to:
+
+* `election-id`: `ingress-controller-leader`
+* `ingress-class`: `nginx`
+* `resourceName` : `<election-id>-<ingress-class>`
+
+Please adapt accordingly if you overwrite either parameter when launching the
+nginx-ingress-controller.
+
 ### Bindings
 
 The ServiceAccount `nginx-ingress-serviceaccount` is bound to the Role

--- a/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
+++ b/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
@@ -72,6 +72,20 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
       - endpoints
     verbs:
       - get


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/ingress/issues/798

Using gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.7
the nginx-controller needs to handle leader-election via configmaps.

To perform the leader-election the nginx-controller needs to have the
appropiate RBAC permissions.

Previously to this fix, the following errors occured:

-  `cannot get configmaps in the namespace "NAMESPACE_PLACEHOLDER". (get configmaps ingress-controller-leader-nginx)`
- `initially creating leader election record: User "system:serviceaccount:NAMESPACE_PLACEHOLDER" cannot create configmaps in the namespace "NAMESPACE_PLACEHOLDER". (post configmaps)`

And another error message concerning `update` (I do not have the logs any more)

Related to:

- https://github.com/kubernetes/ingress/issues/266
- https://github.com/kubernetes/ingress/pull/747