### PR TITLE
fix ingress rbac roles

### DIFF
--- a/examples/rbac/nginx/README.md
+++ b/examples/rbac/nginx/README.md
@@ -37,6 +37,7 @@ able to function as an ingress across the cluster.  These permissions are
 granted to the ClusterRole named `nginx-ingress-clusterrole`
 
 * `configmaps`, `endpoints`, `nodes`, `pods`, `secrets`: list, watch
+* `nodes`: get
 * `services`, `ingresses`: get, list, watch
 * `events`: create, patch
 * `ingresses/status`: update
@@ -48,6 +49,21 @@ permissions are granted to the Role named `nginx-ingress-role`
 
 * `configmaps`, `pods`, `secrets`: get
 * `endpoints`: create, get, update
+
+Furthermore to support leader-election, the nginx-ingress-controller needs to
+have access to a `configmap` using the resourceName `ingress-controller-leader-nginx`
+
+* `configmaps`: create, get, update (for resourceName `ingress-controller-leader-nginx`)
+
+This resourceName is the concatenation of the `election-id` and the
+`ingress-class` as defined by the ingress-controller, which default to:
+
+* `election-id`: `ingress-controller-leader`
+* `ingress-class`: `nginx`
+* `resourceName` : `<election-id>-<ingress-class>`
+
+Please adapt accordingly if you overwrite either parameter when launching the
+nginx-ingress-controller.
 
 ### Bindings
 

--- a/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
+++ b/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
@@ -28,6 +28,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
       - services
     verbs:
       - get
@@ -69,6 +75,20 @@ rules:
       - secrets
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - create
+      - get
+      - update
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
There was 2 things that the current IC (0.9 beta7) needs. (Note that in the pasted api server logs my SA is called `nginx-ingress-controller` and the IC is running in `kube-system`) 

The ClusterRole was missing `get nodes`:

```
RBAC DENY: user "system:serviceaccount:kube-system:nginx-ingress-controller" groups [system:serviceaccounts system:serviceaccounts:kube-system system:authenticated] cannot "get" resource "nodes" named "xxx" cluster-wide
```

The Role was missing `update configmaps`:

```RBAC DENY: user "system:serviceaccount:kube-system:nginx-ingress-controller" groups [system:serviceaccounts system:serviceaccounts:kube-system system:authenticated] cannot "update" resource "configmaps" named "ingress-controller-leader-nginx" in namespace "kube-system"```