### PR TITLE
randomize-upstreams added to the configuration

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -332,6 +332,7 @@ http://nginx.org/en/docs/http/load_balancing.html.
 
 **proxy-send-timeout:** Sets the timeout in seconds for [transmitting a request to the proxied server](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout). The timeout is set only between two successive write operations, not for the transmission of the whole request.
 
+**randomize-upstreams:** By default the upstream servers are sorted in the configuration by ip. If sticky sessions are enabled this can lead to a lumpy distribution of sessions to upstreams in the presence of frequent nginx restarts (the pod with the "lowest" ip will get any new session after a restart). Setting this to true randomizes the order of the upstreams and therefore new sessions will be assigned to a random pod after a restart.
 
 **retry-non-idempotent:** Since 1.9.13 NGINX will not retry non-idempotent requests (POST, LOCK, PATCH) in case of an error in the upstream server.
 

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -199,6 +199,11 @@ type Configuration struct {
 	// Sets the name of the configmap that contains the headers to pass to the backend
 	ProxySetHeaders string `json:"proxy-set-headers,omitempty"`
 
+	// If RandomizeUpstreams is true the upstream ips are not sorted before writing the config. This is
+	// useful to get better random distribution of sticky sessions. This will increase the number of
+	// reloads nginx will incur.
+	RandomizeUpstreams bool `json:"randomize-upstreams,omitempty"`
+
 	// Maximum size of the server names hash tables used in server names, map directive’s values,
 	// MIME types, names of request header strings, etcd.
 	// http://nginx.org/en/docs/hash.html
@@ -316,6 +321,7 @@ func NewDefault() Configuration {
 		MaxWorkerConnections:     16384,
 		MapHashBucketSize:        64,
 		ProxyRealIPCIDR:          defIPCIDR,
+		RandomizeUpstreams:       false,
 		ServerNameHashMaxSize:    1024,
 		ShowServerTokens:         true,
 		SSLBufferSize:            sslBufferSize,


### PR DESCRIPTION
when set to true causes the upstream lists to be randomized. This helps w/ sticky session distribution