### PR TITLE
Added client_max_body_size to authPath location

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -327,6 +327,9 @@ http {
             proxy_set_header            Host {{ $location.ExternalAuth.Host }};
             proxy_ssl_server_name       on;
 
+            client_max_body_size        "{{ $location.Proxy.BodySize }}";
+
+
             set $target {{ $location.ExternalAuth.URL }};
             proxy_pass $target;
         }


### PR DESCRIPTION
Seems like nginx denies the request because it would be over the max body size,
even if `proxy_pass_request_body` is `off`.

This fixes #811

Not sure if it is straight forward to build tests for this. Hope this is ok as it is. For me this fixed my issues at least. Built a docker image and swapped the official one for one with this fix and it works.
