### PR TITLE
rbac-nginx: resourceNames cannot filter create verb

### DIFF
--- a/examples/rbac/nginx/README.md
+++ b/examples/rbac/nginx/README.md
@@ -53,7 +53,13 @@ permissions are granted to the Role named `nginx-ingress-role`
 Furthermore to support leader-election, the nginx-ingress-controller needs to
 have access to a `configmap` using the resourceName `ingress-controller-leader-nginx`
 
-* `configmaps`: create, get, update (for resourceName `ingress-controller-leader-nginx`)
+> Note that resourceNames can NOT be used to limit requests using the “create”
+> verb because authorizers only have access to information that can be obtained
+> from the request URL, method, and headers (resource names in a “create” request
+> are part of the request body).
+
+* `configmaps`: get, update (for resourceName `ingress-controller-leader-nginx`)
+* `configmaps`: create
 
 This resourceName is the concatenation of the `election-id` and the
 `ingress-class` as defined by the ingress-controller, which default to:

--- a/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
+++ b/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
@@ -86,9 +86,14 @@ rules:
       # when launching the nginx-ingress-controller.
       - "ingress-controller-leader-nginx"
     verbs:
-      - create
       - get
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Without this PR applied, one will get:

> with the current master of today

```
E0603 08:57:35.530371       5 leaderelection.go:257] error initially creating leader election record: User "system:serviceaccount:nginx-ingress:default" cannot create configmaps in the namespace "nginx-ingress". (post configmaps)
```

As per https://kubernetes.io/docs/admin/authorization/rbac/
> Notably, resourceNames can NOT be used to limit requests using the “create” verb because authorizers only have access to information that can be obtained from the request URL, method, and headers (resource names in a “create” request are part of the request body).