### PR TITLE
feat(template): wrap IPv6 addresses in []

### DIFF
--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -142,8 +142,23 @@ var (
 		"hasSuffix":                strings.HasSuffix,
 		"toUpper":                  strings.ToUpper,
 		"toLower":                  strings.ToLower,
+		"formatIP":                 formatIP,
 	}
 )
+
+// fomatIP will wrap IPv6 addresses in [] and return IPv4 addresses
+// without modification. If the input cannot be parsed as an IP address
+// it is returned without modification.
+func formatIP(input string) string {
+	ip := net.ParseIP(input)
+	if ip == nil {
+		return input
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return input
+	}
+	return fmt.Sprintf("[%s]", input)
+}
 
 // buildResolvers returns the resolvers reading the /etc/resolv.conf file
 func buildResolvers(a interface{}) string {

--- a/controllers/nginx/pkg/template/template_test.go
+++ b/controllers/nginx/pkg/template/template_test.go
@@ -88,6 +88,25 @@ var (
 	}
 )
 
+func TestFormatIP(t *testing.T) {
+	cases := map[string]struct {
+		Input, Output string
+	}{
+		"ipv4-localhost": {"127.0.0.1", "127.0.0.1"},
+		"ipv4-internet":  {"8.8.8.8", "8.8.8.8"},
+		"ipv6-localhost": {"::1", "[::1]"},
+		"ipv6-internet":  {"2001:4860:4860::8888", "[2001:4860:4860::8888]"},
+		"invalid-ip":     {"nonsense", "nonsense"},
+		"empty-ip":       {"", ""},
+	}
+	for k, tc := range cases {
+		res := formatIP(tc.Input)
+		if res != tc.Output {
+			t.Errorf("%s: called formatIp('%s'); expected '%v' but returned '%v'", k, tc.Input, tc.Output, res)
+		}
+	}
+}
+
 func TestBuildLocation(t *testing.T) {
 	for k, tc := range tmplFuncTestcases {
 		loc := &ingress.Location{

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -226,7 +226,7 @@ http {
         {{ $cfg.LoadBalanceAlgorithm }};
         {{ end }}
         {{ end }}
-        {{ range $server := $upstream.Endpoints }}server {{ $server.Address }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
+        {{ range $server := $upstream.Endpoints }}server {{ $server.Address | formatIP }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
         {{ end }}
     }
     {{ end }}


### PR DESCRIPTION
Add formatIP helper function which will wrap IPv6 addresses
in [] and print IPv4 addresses as is.

Closes #828