### PR TITLE
Make log format json escaping configurable

### DIFF
--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -175,6 +175,10 @@ type Configuration struct {
 	// Default: 4 8k
 	LargeClientHeaderBuffers string `json:"large-client-header-buffers"`
 
+	// Enable json escaping
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
+	LogFormatEscapeJson bool `json:"log-format-escape-json,omitempty"`
+
 	// Customize upstream log_format
 	// http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
 	LogFormatUpstream string `json:"log-format-upstream,omitempty"`
@@ -311,6 +315,7 @@ func NewDefault() Configuration {
 		KeepAlive:                75,
 		KeepAliveRequests:        100,
 		LargeClientHeaderBuffers: "4 8k",
+		LogFormatEscapeJson:      false,
 		LogFormatStream:          logFormatStream,
 		LogFormatUpstream:        logFormatUpstream,
 		MaxWorkerConnections:     16384,

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -93,7 +93,7 @@ http {
     # disable warnings
     uninitialized_variable_warn off;
 
-    log_format upstreaminfo '{{ buildLogFormatUpstream $cfg }}';
+    log_format upstreaminfo {{ if $cfg.LogFormatEscapeJson }}escape=json {{ end }}'{{ buildLogFormatUpstream $cfg }}';
 
     {{/* map urls that should not appear in access.log */}}
     {{/* http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log */}}


### PR DESCRIPTION
This will allow json logging in nginx ingress controllers which greatly
improves ease of log indexing and searching via elasticsearch.

After this change is made, users could set the following properties in the
ingress configmap to enable json logging:

```
log-format-escape-json: "true"
log-format-upstream: '{"proxy_protocol_addr": "$proxy_protocol_addr", "proxy_add_x_forwarded_for": "$proxy_add_x_forwarded_for", "remote_user": "$remote_user", "time_iso8601": "$time_iso8601", "request": "$request", "status": "$status", "body_bytes_sent": "$body_bytes_sent", "http_referer": "$http_referer", "http_user_agent": "$http_user_agent", "request_length": "$request_length", "request_time": "$request_time", "proxy_upstream_name": "$proxy_upstream_name", "upstream_addr": "$upstream_addr", "upstream_response_length": "$upstream_response_length", "upstream_response_time": "$upstream_response_time", "upstream_status": "$upstream_status"}'
```