### PR TITLE
fix semicolon

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -549,7 +549,7 @@ stream {
 
     server {
         listen                  {{ $tcpServer.Port }};
-        {{ if $IsIPV6Enabled }}listen [::]:{{ $tcpServer.Port }}{{ end }}
+        {{ if $IsIPV6Enabled }}listen [::]:{{ $tcpServer.Port }};{{ end }}
         proxy_pass              tcp-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
     }
     {{ end }}


### PR DESCRIPTION
Fix error:
```
[nginx-ingress-controller-3857993355-t195f] 2017/06/13 11:01:58 [emerg]
 66#66: the invalid "proxy_pass" parameter in /tmp/nginx-cfg577765274:756
```