### PR TITLE
Add metric "ssl certificate expiration"

### DIFF
--- a/core/pkg/ingress/sort_ingress.go
+++ b/core/pkg/ingress/sort_ingress.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"time"
 )
 
 // BackendByNameServers sorts upstreams by name
@@ -79,6 +80,8 @@ type SSLCert struct {
 	PemSHA string `json:"pemSha"`
 	// CN contains all the common names defined in the SSL certificate
 	CN []string `json:"cn"`
+	// ExpiresTime contains the expiration of this SSL certificate in timestamp format
+	ExpireTime time.Time `json:"expires"`
 }
 
 // GetObjectKind implements the ObjectKind interface as a noop

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/defaults"
 	"k8s.io/ingress/core/pkg/ingress/resolver"
 	"k8s.io/ingress/core/pkg/ingress/store"
+	"time"
 )
 
 var (
@@ -203,6 +204,8 @@ type Server struct {
 	SSLPassthrough bool `json:"sslPassthrough"`
 	// SSLCertificate path to the SSL certificate on disk
 	SSLCertificate string `json:"sslCertificate"`
+	// SSLExpireTime has the expire date of this certificate
+	SSLExpireTime time.Time `json:"sslExpireTime"`
 	// SSLPemChecksum returns the checksum of the certificate file on disk.
 	// There is no restriction in the hash generator. This checksim can be
 	// used to  determine if the secret changed without the use of file

--- a/core/pkg/net/ssl/ssl.go
+++ b/core/pkg/net/ssl/ssl.go
@@ -131,6 +131,7 @@ func AddOrUpdateCertAndKey(name string, cert, key, ca []byte) (*ingress.SSLCert,
 			PemFileName: pemFileName,
 			PemSHA:      PemSHA1(pemFileName),
 			CN:          cn,
+			ExpireTime:  pemCert.NotAfter,
 		}, nil
 	}
 
@@ -138,6 +139,7 @@ func AddOrUpdateCertAndKey(name string, cert, key, ca []byte) (*ingress.SSLCert,
 		PemFileName: pemFileName,
 		PemSHA:      PemSHA1(pemFileName),
 		CN:          cn,
+		ExpireTime:  pemCert.NotAfter,
 	}, nil
 }
 


### PR DESCRIPTION
* Instrument nginx to expose metric "ssl certficate expiration time "
* Add a console warning message 10 days before the certificate expire.

Alert example:
```
ALERT NginxSSLCertExpire
  IF ingress_controller_ssl_expire_time_seconds < (time() + (10 * 24 * 3600))
  LABELS {service="nginx", severity="critical"}
  ANNOTATIONS {description="SSL certificate for host {{ labels.host }} 
will expire in 10 days. Please renew!", summary="SSL Certificate is about to expire!!"}
```
