### PR TITLE
ensure private key and certificate match

### DIFF
--- a/core/pkg/net/ssl/ssl.go
+++ b/core/pkg/net/ssl/ssl.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
@@ -86,6 +87,12 @@ func AddOrUpdateCertAndKey(name string, cert, key, ca []byte) (*ingress.SSLCert,
 
 	pemCert, err := x509.ParseCertificate(pemBlock.Bytes)
 	if err != nil {
+		_ = os.Remove(tempPemFile.Name())
+		return nil, err
+	}
+
+	//Ensure that certificate and private key have a matching public key
+	if _, err := tls.X509KeyPair(cert, key); err != nil {
 		_ = os.Remove(tempPemFile.Name())
 		return nil, err
 	}


### PR DESCRIPTION
Adding an ingress tls secret with a non matching certificate and private key break at least the nginx-controller permanently until the offending secret is deleted.

In that case nginx refuses to start/reload with an error like this:
```
Error: exit status 1
2017/06/13 12:16:53 [emerg] 51#51: SSL_CTX_use_PrivateKey_file("/ingress-controller/ssl/tls-baremetal-3-example-com.pem") failed (SSL: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch)
nginx: [emerg] SSL_CTX_use_PrivateKey_file("/ingress-controller/ssl/tls-baremetal-3-example-com.pem") failed (SSL: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch)
nginx: configuration file /tmp/nginx-cfg728491545 test failed
```