### PR TITLE
Don't expose certificate metrics for default server

### DIFF
--- a/core/pkg/ingress/controller/metrics.go
+++ b/core/pkg/ingress/controller/metrics.go
@@ -75,7 +75,9 @@ func incReloadErrorCount() {
 func setSSLExpireTime(servers []*ingress.Server) {
 
 	for _, s := range servers {
-		sslExpireTime.WithLabelValues(s.Hostname).Set(float64(s.SSLExpireTime.Unix()))
+		if s.Hostname != defServerName {
+			sslExpireTime.WithLabelValues(s.Hostname).Set(float64(s.SSLExpireTime.Unix()))
+		}
 	}
 
 }


### PR DESCRIPTION
The default server has a self signed certificate so it's not important to monitor
Related to #848 
