### PR TITLE
Rebase glbc on alpine:3.6

### DIFF
--- a/controllers/gce/Dockerfile
+++ b/controllers/gce/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
The new alpine base image should have fixes for CVE-2016-9841 and CVE-2016-9843.
We should probably tag and build a new release (0.9.4?) too.

@nicksardo 

x-ref https://github.com/kubernetes/kubernetes/issues/47386