### PR TITLE
Add feature to allow sticky sessions per location

### DIFF
--- a/controllers/nginx/pkg/template/template_test.go
+++ b/controllers/nginx/pkg/template/template_test.go
@@ -129,7 +129,7 @@ func TestBuildProxyPass(t *testing.T) {
 			Backend:  "upstream-name",
 		}
 
-		pp := buildProxyPass([]*ingress.Backend{}, loc)
+		pp := buildProxyPass("", []*ingress.Backend{}, loc)
 		if !strings.EqualFold(tc.ProxyPass, pp) {
 			t.Errorf("%s: expected \n'%v'\nbut returned \n'%v'", k, tc.ProxyPass, pp)
 		}

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -225,15 +225,24 @@ http {
     proxy_pass_header Server;
     {{ end }}
 
-    {{range $name, $upstream := $backends}}
-    upstream {{$upstream.Name}} {
-        {{ if eq $upstream.SessionAffinity.AffinityType "cookie" }}
-        sticky hash={{$upstream.SessionAffinity.CookieSessionAffinity.Hash}} name={{$upstream.SessionAffinity.CookieSessionAffinity.Name}}  httponly;
-        {{ else }}
+    {{ range $name, $upstream := $backends }}
+    {{ if eq $upstream.SessionAffinity.AffinityType "cookie" }}
+    upstream sticky-{{ $upstream.Name }} {
+        sticky hash={{ $upstream.SessionAffinity.CookieSessionAffinity.Hash }} name={{ $upstream.SessionAffinity.CookieSessionAffinity.Name }}  httponly;
+
+        {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
+        keepalive {{ $cfg.UpstreamKeepaliveConnections }};
+        {{ end }}
+
+        {{ range $server := $upstream.Endpoints }}server {{ $server.Address | formatIP }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
+        {{ end }}
+    }
+    {{ end }}
+
+    upstream {{ $upstream.Name }} {
         # Load balance algorithm; empty for round robin, which is the default
         {{ if ne $cfg.LoadBalanceAlgorithm "round_robin" }}
         {{ $cfg.LoadBalanceAlgorithm }};
-        {{ end }}
         {{ end }}
 
         {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
@@ -343,8 +352,7 @@ http {
         {{ end }}
 
         location {{ $path }} {
-            set $proxy_upstream_name "{{ $location.Backend }}";
-
+            set $proxy_upstream_name "{{ buildUpstreamName $server.Hostname $backends $location }}";
             {{ if isLocationAllowed $location }}
             {{ if gt (len $location.Whitelist.CIDR) 0 }}
             if ({{ buildDenyVariable (print $server.Hostname "_"  $path) }}) {
@@ -439,7 +447,7 @@ http {
             {{/* Add any additional configuration defined */}}
             {{ $location.ConfigurationSnippet }}
 
-            {{ buildProxyPass $backends $location }}
+            {{ buildProxyPass $server.Hostname $backends $location }}
             {{ else }}
             #{{ $location.Denied }}
             return 503;

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -791,14 +791,21 @@ func (ic *GenericController) createUpstreams(data []interface{}) map[string]*ing
 				if !upstreams[name].Secure {
 					upstreams[name].Secure = secUpstream.Secure
 				}
+
 				if upstreams[name].SecureCACert.Secret == "" {
 					upstreams[name].SecureCACert = secUpstream.CACert
 				}
+
 				if upstreams[name].SessionAffinity.AffinityType == "" {
 					upstreams[name].SessionAffinity.AffinityType = affinity.AffinityType
 					if affinity.AffinityType == "cookie" {
 						upstreams[name].SessionAffinity.CookieSessionAffinity.Name = affinity.CookieConfig.Name
 						upstreams[name].SessionAffinity.CookieSessionAffinity.Hash = affinity.CookieConfig.Hash
+
+						if _, ok := upstreams[name].SessionAffinity.CookieSessionAffinity.Locations[rule.Host]; !ok {
+							upstreams[name].SessionAffinity.CookieSessionAffinity.Locations[rule.Host] = []string{}
+						}
+						upstreams[name].SessionAffinity.CookieSessionAffinity.Locations[rule.Host] = append(upstreams[name].SessionAffinity.CookieSessionAffinity.Locations[rule.Host], path.Path)
 					}
 				}
 

--- a/core/pkg/ingress/controller/util.go
+++ b/core/pkg/ingress/controller/util.go
@@ -39,6 +39,11 @@ func newUpstream(name string) *ingress.Backend {
 	return &ingress.Backend{
 		Name:      name,
 		Endpoints: []ingress.Endpoint{},
+		SessionAffinity: ingress.SessionAffinityConfig{
+			CookieSessionAffinity: ingress.CookieSessionAffinity{
+				Locations: make(map[string][]string),
+			},
+		},
 	}
 }
 

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -174,8 +174,9 @@ type SessionAffinityConfig struct {
 
 // CookieSessionAffinity defines the structure used in Affinity configured by Cookies.
 type CookieSessionAffinity struct {
-	Name string `json:"name"`
-	Hash string `json:"hash"`
+	Name      string              `json:"name"`
+	Hash      string              `json:"hash"`
+	Locations map[string][]string `json:"locations,omitempty"`
 }
 
 // Endpoint describes a kubernetes endpoint in a backend


### PR DESCRIPTION
This PR enables sticky session per location inside a server
Also avoids reusing the same upstream block when sticky sessions is not configured

```
kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/http-svc.yaml
```

```
echo "
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    ingress.kubernetes.io/affinity: cookie
    ingress.kubernetes.io/session-cookie-hash: sha1
    ingress.kubernetes.io/session-cookie-name: route
  name: nginx-test
  namespace: default
spec:
  rules:
  - host: sticky-ingress.example.com
    http:
      paths:
      - backend:
          serviceName: http-svc
          servicePort: 80
        path: /

---

apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: nginx-test-ns
  namespace: default
spec:
  rules:
  - host: no-sticky-ingress.example.com
    http:
      paths:
      - backend:
          serviceName: http-svc
          servicePort: 80
        path: /

---

apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: nginx-test-ns-path
  namespace: default
spec:
  rules:
  - host: sticky-ingress.example.com
    http:
      paths:
      - backend:
          serviceName: http-svc
          servicePort: 80
        # Add a custom path that use the same service without sticky sessions
        path: /no-sticky-session
" | kubectl create -f -
```

**Check sticky sessions is working:**
```
$ kubectl exec -n kube-system <ingress pod> -- curl -v localhost  -H'Host: sticky-ingress.example.com'
```

It must appear something like
```
< Set-Cookie: route=dc89ae303c62a8bfce8bf32f06d27c31f0980ef7; Path=/; HttpOnly
```

**Check a different host with no sticky sessions that uses the same service:**
```
$ kubectl exec -n kube-system <ingress pod> -- curl -v localhost  -H'Host: no-sticky-ingress.example.com'
```

**Now check a different path in the host with sticky sessions where the feature is not enabled:**
```
$ kubectl exec -n kube-system nginx-ingress-controller-3401347994-vjvhv  -it -- curl -v localhost/no-sticky-session  -H'Host: stickyingress.example.com'
```

fixes #844
fixes #771