### PR TITLE
WIP: nginx-slim and nginx-ingress-controller: dropping privileges from root

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -85,20 +85,20 @@ func newNGINXController() ingress.Controller {
 			Default: &server{
 				Hostname:      "localhost",
 				IP:            "127.0.0.1",
-				Port:          442,
+				Port:          8442,
 				ProxyProtocol: true,
 			},
 		},
 	}
 
-	listener, err := net.Listen("tcp", ":443")
+	listener, err := net.Listen("tcp", ":8443")
 	if err != nil {
 		glog.Fatalf("%v", err)
 	}
 
 	proxyList := &proxyproto.Listener{Listener: listener}
 
-	// start goroutine that accepts tcp connections in port 443
+	// start goroutine that accepts tcp connections in port 8443
 	go func() {
 		for {
 			var conn net.Conn
@@ -204,7 +204,7 @@ NGINX master process died (%v): %v
 		cmd = exec.Command(n.binary, "-c", cfgPath)
 		// we wait until the workers are killed
 		for {
-			conn, err := net.DialTimeout("tcp", "127.0.0.1:80", 1*time.Second)
+			conn, err := net.DialTimeout("tcp", "127.0.0.1:8080", 1*time.Second)
 			if err != nil {
 				break
 			}

--- a/controllers/nginx/rootfs/Dockerfile
+++ b/controllers/nginx/rootfs/Dockerfile
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-slim-amd64:0.18
+FROM gcr.io/google_containers/nginx-slim-amd64:0.19
 
+USER root
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   diffutils \
   --no-install-recommends \
@@ -26,4 +27,5 @@ ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY . /
 
+USER nginx
 CMD ["/nginx-ingress-controller"]

--- a/controllers/nginx/rootfs/etc/nginx/nginx.conf
+++ b/controllers/nginx/rootfs/etc/nginx/nginx.conf
@@ -1,5 +1,5 @@
 # A very simple nginx configuration file that forces nginx to start.
-pid /run/nginx.pid;
+pid /run/nginx/nginx.pid;
 
 events {}
 http {}

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -6,7 +6,7 @@
 daemon off;
 
 worker_processes {{ $cfg.WorkerProcesses }};
-pid /run/nginx.pid;
+pid /run/nginx/nginx.pid;
 {{ if ne .MaxOpenFiles 0 }}
 worker_rlimit_nofile {{ .MaxOpenFiles }};
 {{ end}}

--- a/images/echoheaders/Dockerfile
+++ b/images/echoheaders/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-slim:0.18
+FROM gcr.io/google_containers/nginx-slim:0.19
 
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD template.lua /usr/local/share/lua/5.1/

--- a/images/echoheaders/Makefile
+++ b/images/echoheaders/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # TAG 0.0 shouldn't clobber any release builds
-TAG = 1.6
+TAG = 1.7
 PREFIX = gcr.io/google_containers/echoserver
 
 container:

--- a/images/nginx-slim/Dockerfile
+++ b/images/nginx-slim/Dockerfile
@@ -26,6 +26,7 @@ RUN /tmp/build.sh
 RUN ln -sf /dev/stdout /var/log/nginx/access.log
 RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
-EXPOSE 80 443
+EXPOSE 8080 8443
 
+USER nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/images/nginx-slim/Makefile
+++ b/images/nginx-slim/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG = 0.18
+TAG = 0.19
 REGISTRY = gcr.io/google_containers
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm ppc64le

--- a/images/nginx-slim/rc.yaml
+++ b/images/nginx-slim/rc.yaml
@@ -29,6 +29,43 @@ spec:
     spec:
       containers:
       - name: nginxslim
-        image: gcr.io/google_containers/nginx-slim:0.16
+        image: gcr.io/google_containers/nginx-slim:0.19
         ports:
-        - containerPort: 80
+        - containerPort: 8080
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 105
+          privileged: false
+          capabilities:
+            drop:
+            - AUDIT_WRITE
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - FSETID
+            - KILL
+            - MKNOD
+            - NET_BIND_SERVICE
+            - NET_RAW
+            - SETFCAP
+            - SETGID
+            - SETUID
+            - SETPCAP
+            - SYS_CHROOT
+        volumeMounts:
+        - name: proxy
+          mountPath: /var/lib/nginx/proxy
+        - name: fastcgi
+          mountPath: /var/lib/nginx/fastcgi
+        - name: pidfile
+          mountPath: /run/nginx
+      securityContext:
+        fsGroup: 106
+      volumes:
+        - name: proxy
+          emptyDir: {}
+        - name: fastcgi
+          emptyDir: {}
+        - name: pidfile
+          emptyDir: {}


### PR DESCRIPTION
## What's all this security stuff then? 💪 

I can't identify a reason why nginx ingress controller pods should be running as root so I dropped privileges to support a strict [container level security context](https://kubernetes.io/docs/concepts/policy/security-context/#container-level-security-context).

In strictly secured kubernetes clusters this pod just ends up on a whitelist of those that run as root and I don't want to do this anymore. Neither should anyone else imo 😄 

### some questions:

1. In order to support `readOnlyRootFilesystem` I've mounted a number of [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volumes in the example replication contoller. I don't think this is the best place to keep the pid file but I'm unsure of another solution other than moving it into a non-standard directory like `/etc/nginx/nginx.pid` or something. Help?

1. This should be considered a **major** (read: breaking) change. Does a minor version increment support this change? I expect anyone flipping a minor version without reading the change log would incur downtime on their services while they deal with security controls.

1. Other nits addressed in review comments 
