### PR TITLE
Release ubuntu-slim:0.12

### DIFF
--- a/images/ubuntu-slim/Makefile
+++ b/images/ubuntu-slim/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG ?= 0.11
+TAG ?= 0.12
 REGISTRY = gcr.io/google_containers
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le


### PR DESCRIPTION
Main reason to do this is to pick up the fix for CVE-2017-1000366.

I can't seem to build the non-amd64 images, though, as noted in https://github.com/kubernetes/ingress/pull/743#issuecomment-30959171.