### PR TITLE
Don't use $proxy_protocol var which may be undefined.

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -137,12 +137,10 @@ http {
 
     map $pass_access_scheme $the_x_forwarded_for {
        default           $remote_addr;
-       https             $proxy_protocol_addr;
     }
 
     map $pass_access_scheme $the_real_ip {
        default           $remote_addr;
-       https             $proxy_protocol_addr;
     }
 
     # map port 442 to 443 for header X-Forwarded-Port


### PR DESCRIPTION
I'm on AWS with an nginx-ingress-controller behind an ELB (created by a kubernetes Service of type LoadBalancer). I set the following annotations:

```
      annotations:
        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
        service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: ""
```

which disable proxy protocol and enable http backend protocol, which cause the ELB to set X-Forwarded-For and X-Forwarded-Proto headers when communicating with the backend (nginx in this case).

And I have this annotation on the nginx-ingress-controller:

```
      use-proxy-protocol: "false"
```

However, the X-Forwarded-For header is not being passed along by nginx to its upstream services. This is because when the X-Forwarded-Proto is set to "https", the nginx config on line 128 sets $pass_access_scheme to "https", which in turn results in $the_x_forwarded_for being set to $proxy_protocol_addr on line 140.

Because I'm not using proxy protocol, $proxy_protocol_addr is unset. However, when using either proxy protocol or X-Forwarded-For, $remote_addr is set correctly by the `real_ip_header` directives on lines 24 and 27.

This pull request solves my problem, though I can't say it doesn't break other configurations. My goal with this PR is to document the issue.

See https://github.com/kubernetes/ingress/issues/800#issuecomment-305203830