### PR TITLE
Add PHOST to backend

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -137,12 +137,12 @@ http {
 
     map $pass_access_scheme $the_x_forwarded_for {
        default           $remote_addr;
-       https             $proxy_protocol_addr;
+    #   https             $proxy_protocol_addr;
     }
 
     map $pass_access_scheme $the_real_ip {
        default           $remote_addr;
-       https             $proxy_protocol_addr;
+    #   https             $proxy_protocol_addr;
     }
 
     # map port 442 to 443 for header X-Forwarded-Port
@@ -165,12 +165,18 @@ http {
         xml              application/xml;
         text             text/plain;
     }
-
-    # Obtain best http host
-    map $http_host $best_http_host {
-        default          $http_host;
+    
+    # Obtain CUSTOM host (PHOST)
+    map $http_phost $best_http_host {
+        default          $http_phost;
         ''               $host;
     }
+
+    # Obtain best http host
+    #map $http_host $best_http_host {
+    #    default          $http_host;
+    #    ''               $host;
+    #}
 
     server_name_in_redirect off;
     port_in_redirect        off;


### PR DESCRIPTION
the road of request : nginx-> nginx-ingress-> tomcat. If use https, the first nginx use 443 port . the next nginx-ingress and tomcat use 80
port.

so nginx-ingress use "PHOST" to show the real host for backends. Removes
https support from nginx-ingress.