### PR TITLE
[doc] Update NGinX status port to 18080

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -371,7 +371,7 @@ Using this two headers is possible to use a custom backend service like [this on
 
 The ngx_http_stub_status_module module provides access to basic status information. This is the default module active in the url `/nginx_status`.
 This controller provides an alternative to this module using [nginx-module-vts](https://github.com/vozlt/nginx-module-vts) third party module.
-To use this module just provide a config map with the key `enable-vts-status=true`. The URL is exposed in the port 8080.
+To use this module just provide a config map with the key `enable-vts-status=true`. The URL is exposed in the port 18080.
 Please check the example `example/rc-default.yaml`
 
 ![nginx-module-vts screenshot](https://cloud.githubusercontent.com/assets/3648408/10876811/77a67b70-8183-11e5-9924-6a6d0c5dc73a.png "screenshot with filter")


### PR DESCRIPTION
The docs still states to reach the /nginx_status page on port 8080.
However, it seems that this has been changed :)