### PR TITLE
WIP -- Feedback Requested: HSTS for SSL Terminated Environments

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -298,7 +298,7 @@ http {
         ssl_certificate_key                     {{ $server.SSLCertificate }};
         {{ end }}
 
-        {{ if (and (not (empty $server.SSLCertificate)) $cfg.HSTS) }}
+        {{ if (and $cfg.HSTS (or (not (empty $server.SSLCertificate)) $location.Redirect.ForceSSLRedirect)) }}
         more_set_headers                        "Strict-Transport-Security: max-age={{ $cfg.HSTSMaxAge }}{{ if $cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }};{{ if $cfg.HSTSPreload }} preload{{ end }}";
         {{ end }}
 


### PR DESCRIPTION
We were hoping to turn on HSTS for our SSL terminated cluster.

What are your thoughts on keying off of `ingress.kubernetes.io/force-ssl-redirect` to support that? Or do you think we should have an alternate annotation like `ingress.kubernetes.io/force-hsts`?