### PR TITLE
Apply the 'ssl-redirect' annotation per-location

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -313,13 +313,6 @@ http {
         ssl_verify_depth {{ $location.CertificateAuth.ValidationDepth }};
         {{ end }}
 
-        {{ if (or $location.Redirect.ForceSSLRedirect (and (not (empty $server.SSLCertificate)) $location.Redirect.SSLRedirect)) }}
-        # enforce ssl on server side
-        if ($pass_access_scheme = http) {
-            return 301 https://$best_http_host$request_uri;
-        }
-        {{ end }}
-
         {{ if not (empty $location.Redirect.AppRoot)}}
         if ($uri = /) {
             return 302 {{ $location.Redirect.AppRoot }};
@@ -353,6 +346,14 @@ http {
 
         location {{ $path }} {
             set $proxy_upstream_name "{{ buildUpstreamName $server.Hostname $backends $location }}";
+
+            {{ if (or $location.Redirect.ForceSSLRedirect (and (not (empty $server.SSLCertificate)) $location.Redirect.SSLRedirect)) }}
+            # enforce ssl on server side
+            if ($pass_access_scheme = http) {
+                return 301 https://$best_http_host$request_uri;
+            }
+            {{ end }}
+
             {{ if isLocationAllowed $location }}
             {{ if gt (len $location.Whitelist.CIDR) 0 }}
             if ({{ buildDenyVariable (print $server.Hostname "_"  $path) }}) {


### PR DESCRIPTION
This is needed to avoid ingress definitions with different settings for SSL
redirection conflicting with each other.

NB: This was discussed in the review of #427, but ultimately not addressed.

---
In my test setup I have regular ingress definitions with enabled SSL-redirect, and kube-lego is adding '/.well-known/acme-challenge/...' ingress definitions that at least for a while need to _not_ use ssl-redirection. In kube-lego's log files one can see the problem:
~~~~
time="2017-06-27T10:29:01Z" level=debug msg="testing reachability of http://DOMAIN.TLD/.well-known/acme-challenge/_selftest" context=acme domain=DOMAIN.TLD
time="2017-06-27T10:29:01Z" level=debug msg="error while authorizing: reachability test failed: Get https://DOMAIN.TLD/.well-known/acme-challenge/_selftest: x509: certificate signed by unknown authority" context=acme domain=DOMAIN.TLD
~~~~

Note that the reachability test wants to use 'http' (see https://github.com/jetstack/kube-lego/blob/master/pkg/acme/cert_request.go#L47 for the request, and https://github.com/jetstack/kube-lego/blob/master/pkg/provider/nginx/nginx.go#L119 for the ingress configuration using ssl-redirect=false), but then follows the redirect to 'https' -- which uses the "Kubernetes Ingress Controller Fake Certificate".