### PR TITLE
Make proxy-real-ip-cidr a comma separated list

### DIFF
--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -43,9 +43,6 @@ const (
 	// max-age is the time, in seconds, that the browser should remember that this site is only to be accessed using HTTPS.
 	hstsMaxAge = "15724800"
 
-	// If UseProxyProtocol is enabled defIPCIDR defines the default the IP/network address of your external load balancer
-	defIPCIDR = "0.0.0.0/0"
-
 	gzipTypes = "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
 
 	logFormatUpstream = `%v - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status`
@@ -198,7 +195,7 @@ type Configuration struct {
 
 	// If UseProxyProtocol is enabled ProxyRealIPCIDR defines the default the IP/network address
 	// of your external load balancer
-	ProxyRealIPCIDR string `json:"proxy-real-ip-cidr,omitempty"`
+	ProxyRealIPCIDR []string `json:"proxy-real-ip-cidr,omitempty"`
 
 	// Sets the name of the configmap that contains the headers to pass to the backend
 	ProxySetHeaders string `json:"proxy-set-headers,omitempty"`
@@ -305,6 +302,8 @@ type Configuration struct {
 
 // NewDefault returns the default nginx configuration
 func NewDefault() Configuration {
+    defIPCIDR := make([]string, 0)
+    defIPCIDR = append(defIPCIDR, "0.0.0.0/0")
 	cfg := Configuration{
 		AllowBackendServerHeader:   false,
 		ClientHeaderBufferSize:     "1k",

--- a/controllers/nginx/pkg/template/configmap.go
+++ b/controllers/nginx/pkg/template/configmap.go
@@ -30,6 +30,7 @@ const (
 	customHTTPErrors     = "custom-http-errors"
 	skipAccessLogUrls    = "skip-access-log-urls"
 	whitelistSourceRange = "whitelist-source-range"
+    proxyRealIPCIDR      = "proxy-real-ip-cidr"
 )
 
 // ReadConfig obtains the configuration defined by the user merged with the defaults.
@@ -45,6 +46,7 @@ func ReadConfig(src map[string]string) config.Configuration {
 	errors := make([]int, 0)
 	skipUrls := make([]string, 0)
 	whitelist := make([]string, 0)
+    proxylist := make([]string, 0)
 
 	if val, ok := conf[customHTTPErrors]; ok {
 		delete(conf, customHTTPErrors)
@@ -65,11 +67,18 @@ func ReadConfig(src map[string]string) config.Configuration {
 		delete(conf, whitelistSourceRange)
 		whitelist = append(whitelist, strings.Split(val, ",")...)
 	}
+	if val, ok := conf[proxyRealIPCIDR]; ok {
+		delete(conf, proxyRealIPCIDR)
+		proxylist = append(proxylist, strings.Split(val, ",")...)
+	} else {
+        proxylist = append(proxylist, "0.0.0.0/0")
+    }
 
 	to := config.NewDefault()
 	to.CustomHTTPErrors = filterErrors(errors)
 	to.SkipAccessLogURLs = skipUrls
 	to.WhitelistSourceRange = whitelist
+    to.ProxyRealIPCIDR = proxylist
 
 	config := &mapstructure.DecoderConfig{
 		Metadata:         nil,

--- a/controllers/nginx/pkg/template/configmap_test.go
+++ b/controllers/nginx/pkg/template/configmap_test.go
@@ -42,6 +42,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"use-gzip":                   "true",
 		"enable-dynamic-tls-records": "false",
 		"gzip-types":                 "text/html",
+        "proxy-real-ip-cidr":         "1.1.1.1/8,2.2.2.2/24",
 	}
 	def := config.NewDefault()
 	def.CustomHTTPErrors = []int{300, 400}
@@ -52,6 +53,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.EnableDynamicTLSRecords = false
 	def.UseProxyProtocol = true
 	def.GzipTypes = "text/html"
+    def.ProxyRealIPCIDR = []string{"1.1.1.1/8", "2.2.2.2/24"}
 
 	to := ReadConfig(conf)
 	if diff := pretty.Compare(to, def); diff != "" {

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -20,10 +20,14 @@ events {
 http {
     {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
     {{ if $cfg.UseProxyProtocol }}
-    set_real_ip_from    {{ $cfg.ProxyRealIPCIDR }};
+    {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
+    set_real_ip_from    {{ $trusted_ip }};
+    {{ end }}
     real_ip_header      proxy_protocol;
     {{ else }}
-    set_real_ip_from    {{ $cfg.ProxyRealIPCIDR }};
+    {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
+    set_real_ip_from    {{ $trusted_ip }};
+    {{ end }}
     real_ip_header      X-Forwarded-For;
     {{ end }}
 


### PR DESCRIPTION
Allows config maps to accept proxy-real-ip-cidr as a comma separated list like whitelist-source-range, e.g.

`proxy-real-ip-cidr: "1.1.1.1/8,2.2.2.2/24"`

This resolves #692