### PR TITLE
Release nginx ingress controller 0.9-beta.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ controllers:
 
 .PHONY: docker-build
 docker-build:
-	make -C controllers/nginx container
+	make -C controllers/nginx all-container
 
 .PHONY: docker-push
 docker-push:

--- a/controllers/nginx/Changelog.md
+++ b/controllers/nginx/Changelog.md
@@ -1,5 +1,53 @@
 Changelog
 
+### 0.9-beta.9
+
+**Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9`
+
+*New Features:*
+
+- Add support for arm and ppc64le
+
+
+*Changes:*
+
+- [X] [#548](https://github.com/kubernetes/ingress/pull/548) nginx: support multidomain certificates
+- [X] [#620](https://github.com/kubernetes/ingress/pull/620) [nginx] Listening ports are not configurable, so ingress can't be run multiple times per node when using CNI
+- [X] [#648](https://github.com/kubernetes/ingress/pull/648) publish-service argument isn't honored when ELB is internal only facing.
+- [X] [#833](https://github.com/kubernetes/ingress/pull/833) WIP: Avoid reloads implementing Equals in structs
+- [X] [#838](https://github.com/kubernetes/ingress/pull/838) Feature request: Add ingress annotation to enable upstream "keepalive" option
+- [X] [#844](https://github.com/kubernetes/ingress/pull/844) ingress annotations affinity is not working
+- [X] [#862](https://github.com/kubernetes/ingress/pull/862) Avoid reloads implementing Equaler interface
+- [X] [#864](https://github.com/kubernetes/ingress/pull/864) Remove dead code
+- [X] [#868](https://github.com/kubernetes/ingress/pull/868) Lint nginx code
+- [X] [#871](https://github.com/kubernetes/ingress/pull/871) Add feature to allow sticky sessions per location
+- [X] [#873](https://github.com/kubernetes/ingress/pull/873) Update README.md
+- [X] [#876](https://github.com/kubernetes/ingress/pull/876) Add information about nginx controller flags
+- [X] [#878](https://github.com/kubernetes/ingress/pull/878) Update go to 1.8.3
+- [X] [#881](https://github.com/kubernetes/ingress/pull/881) Option to not remove loadBalancer status record?
+- [X] [#882](https://github.com/kubernetes/ingress/pull/882) Add flag to skip the update of Ingress status on shutdown
+- [X] [#885](https://github.com/kubernetes/ingress/pull/885) Don't use $proxy_protocol var which may be undefined.
+- [X] [#886](https://github.com/kubernetes/ingress/pull/886) Add support for SubjectAltName in SSL certificates
+- [X] [#888](https://github.com/kubernetes/ingress/pull/888) Update nginx-slim to 0.19
+- [X] [#889](https://github.com/kubernetes/ingress/pull/889) Add PHOST to backend
+- [X] [#890](https://github.com/kubernetes/ingress/pull/890) Improve variable configuration for source IP address
+- [X] [#892](https://github.com/kubernetes/ingress/pull/892) Add upstream keepalive connections cache
+- [X] [#897](https://github.com/kubernetes/ingress/pull/897) Update outdated ingress resource link
+- [X] [#898](https://github.com/kubernetes/ingress/pull/898) add error check right when reload nginx fail
+- [X] [#899](https://github.com/kubernetes/ingress/pull/899) Fix nginx error check
+- [X] [#900](https://github.com/kubernetes/ingress/pull/900) After #862 changes in the configmap do not trigger a reload
+- [X] [#901](https://github.com/kubernetes/ingress/pull/901) [doc] Update NGinX status port to 18080
+- [X] [#902](https://github.com/kubernetes/ingress/pull/902) Always reload after a change in the configuration
+- [X] [#904](https://github.com/kubernetes/ingress/pull/904) Fix nginx sticky sessions
+- [X] [#906](https://github.com/kubernetes/ingress/pull/906) Fix race condition with closed channels
+- [X] [#907](https://github.com/kubernetes/ingress/pull/907) nginx/proxy: allow specifying next upstream behaviour
+- [X] [#910](https://github.com/kubernetes/ingress/pull/910) Feature request: use `X-Forwarded-Host` from the reverse proxy before
+- [X] [#911](https://github.com/kubernetes/ingress/pull/911) Improve X-Forwarded-Host support
+- [X] [#915](https://github.com/kubernetes/ingress/pull/915) Release nginx-slim 0.20
+- [X] [#916](https://github.com/kubernetes/ingress/pull/916) Add arm and ppc64le support
+- [X] [#919](https://github.com/kubernetes/ingress/pull/919) Apply the 'ssl-redirect' annotation per-location
+- [X] [#922](https://github.com/kubernetes/ingress/pull/922) Add example of TLS termination using a classic ELB
+
 ### 0.9-beta.8
 
 **Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8`

--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -3,7 +3,7 @@ all: push
 BUILDTAGS=
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
-TAG?=0.9.0-beta.8
+TAG?=0.9.0-beta.9
 REGISTRY?=gcr.io/google_containers
 GOOS?=linux
 DOCKER?=gcloud docker --

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,7 +259,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: ingress-nginx
         imagePullPolicy: Always
         ports:

--- a/examples/aws/nginx/nginx-ingress-controller.yaml
+++ b/examples/aws/nginx/nginx-ingress-controller.yaml
@@ -101,7 +101,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: ingress-nginx
         imagePullPolicy: Always
         ports:

--- a/examples/customization/configuration-snippets/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/configuration-snippets/nginx/nginx-ingress-controller.yaml
@@ -19,7 +19,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/custom-configuration/nginx/nginx-custom-configuration.yaml
+++ b/examples/customization/custom-configuration/nginx/nginx-custom-configuration.yaml
@@ -22,7 +22,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/custom-errors/nginx/rc-custom-errors.yaml
+++ b/examples/customization/custom-errors/nginx/rc-custom-errors.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-lb
         imagePullPolicy: Always
         readinessProbe:

--- a/examples/customization/custom-headers/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/custom-headers/nginx/nginx-ingress-controller.yaml
@@ -19,7 +19,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/custom-template/custom-template.yaml
+++ b/examples/customization/custom-template/custom-template.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-lb
         imagePullPolicy: Always
         readinessProbe:

--- a/examples/customization/custom-vts-metrics/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/custom-vts-metrics/nginx/nginx-ingress-controller.yaml
@@ -22,7 +22,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/ssl-dh-param/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/ssl-dh-param/nginx/nginx-ingress-controller.yaml
@@ -19,7 +19,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
+++ b/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-lb
         readinessProbe:
           httpGet:

--- a/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
@@ -71,7 +71,7 @@ spec:
       hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/deployment/nginx/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/nginx-ingress-controller.yaml
@@ -22,7 +22,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/rbac/nginx/nginx-ingress-controller.yml
+++ b/examples/rbac/nginx/nginx-ingress-controller.yml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
           args:
              - /nginx-ingress-controller
              - --default-backend-service=default/default-http-backend

--- a/examples/scaling-deployment/nginx/nginx-ingress-deployment.yaml
+++ b/examples/scaling-deployment/nginx/nginx-ingress-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/static-ip/nginx/nginx-ingress-controller.yaml
+++ b/examples/static-ip/nginx/nginx-ingress-controller.yaml
@@ -18,7 +18,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/tcp/nginx/README.md
+++ b/examples/tcp/nginx/README.md
@@ -47,7 +47,7 @@ nginx-ingress-controller   1         1         1         3m
 $ kubectl -n kube-system describe rc nginx-ingress-controller
 Name:           nginx-ingress-controller
 Namespace:      kube-system
-Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
 Selector:       k8s-app=nginx-tcp-ingress-lb
 Labels:         k8s-app=nginx-ingress-lb
 Annotations:    <none>

--- a/examples/tcp/nginx/nginx-tcp-ingress-controller.yaml
+++ b/examples/tcp/nginx/nginx-tcp-ingress-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-tcp-ingress-lb
         readinessProbe:
           httpGet:

--- a/examples/tls-termination/elb-nginx/nginx-ingress-controller.yaml
+++ b/examples/tls-termination/elb-nginx/nginx-ingress-controller.yaml
@@ -105,7 +105,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: quay.io/aledbf/nginx-ingress-controller:0.154
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
         name: ingress-nginx
         imagePullPolicy: Always
         ports:

--- a/examples/udp/nginx/README.md
+++ b/examples/udp/nginx/README.md
@@ -53,7 +53,7 @@ nginx-udp-ingress-controller   1         1         1         13m
 $ kubectl -n kube-system describe rc nginx-udp-ingress-controller
 Name:           nginx-udp-ingress-controller
 Namespace:      kube-system
-Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
 Selector:       k8s-app=nginx-udp-ingress-lb
 Labels:         k8s-app=nginx-udp-ingress-lb
 Annotations:    <none>

--- a/examples/udp/nginx/nginx-udp-ingress-controller.yaml
+++ b/examples/udp/nginx/nginx-udp-ingress-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.9
         name: nginx-udp-ingress-lb
         readinessProbe:
           httpGet:


### PR DESCRIPTION
Replaces PR #905

Temporal images: 
```console
quay.io/aledbf/nginx-ingress-controller-ppc64le:0.156                               
quay.io/aledbf/nginx-ingress-controller-arm:0.156
quay.io/aledbf/nginx-ingress-controller-amd64:0.156
quay.io/aledbf/nginx-ingress-controller:0.156
```