### PR TITLE
Add release task in Makefiles and avoid multiple builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ docker-build:
 docker-push:
 	make -C controllers/nginx all-push
 
+.PHONE: release
+release:
+	make -C controllers/nginx release
+
 .PHONY: ginkgo
 ginkgo:
 	go get github.com/onsi/ginkgo/ginkgo

--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -88,13 +88,13 @@ ifeq ($(ARCH), amd64)
 endif
 
 push: .push-$(ARCH)
-.push-$(ARCH): .container-$(ARCH)
+.push-$(ARCH):
 	$(DOCKER) push $(MULTI_ARCH_IMG):$(TAG)
 ifeq ($(ARCH), amd64)
 	$(DOCKER) push $(IMAGE):$(TAG)
 endif
 
-clean: 
+clean:
 	$(DOCKER) rmi -f $(MULTI_ARCH_IMG):$(TAG) || true
 
 build: clean
@@ -123,3 +123,6 @@ cover:
 vet:
 	@echo "+ $@"
 	@go vet $(shell go list ${PKG}/... | grep -v vendor)
+
+release: all-container all-push
+	echo "done"


### PR DESCRIPTION
This PR add the `release` task so simplify the release process. Just run `make release`