### PR TITLE
Add support for proxy protocol in TCP services

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -314,8 +314,8 @@ version to fully support Kube-Lego is nginx Ingress controller 0.8.
 
 ## Exposing TCP services
 
-Ingress does not support TCP services (yet). For this reason this Ingress controller uses the flag `--tcp-services-configmap` to point to an existing config map where the key is the external port to use and the value is `<namespace/service name>:<service port>`
-It is possible to use a number or the name of the port.
+Ingress does not support TCP services (yet). For this reason this Ingress controller uses the flag `--tcp-services-configmap` to point to an existing config map where the key is the external port to use and the value is `<namespace/service name>:<service port>:[PROXY]`
+It is possible to use a number or the name of the port. The last field is optional. Adding `PROXY` in the last field we can enable Proxy Protocol in a TCP service.
 
 The next example shows how to expose the service `example-go` running in the namespace `default` in the port `8080` using the port `9000`
 ```

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -562,22 +562,22 @@ stream {
 
     # TCP services
     {{ range $i, $tcpServer := .TCPBackends }}
-    upstream tcp-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }} {
+    upstream tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }} {
     {{ range $j, $endpoint := $tcpServer.Endpoints }}
         server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
     {{ end }}
     }
-
     server {
-        listen                  {{ $tcpServer.Port }};
-        {{ if $IsIPV6Enabled }}listen                  [::]:{{ $tcpServer.Port }};{{ end }}
-        proxy_pass              tcp-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
+        listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};
+        {{ if $IsIPV6Enabled }}listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};{{ end }}
+        proxy_pass              tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
     }
+
     {{ end }}
 
     # UDP services
     {{ range $i, $udpServer := .UDPBackends }}
-    upstream udp-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }} {
+    upstream udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }} {
     {{ range $j, $endpoint := $udpServer.Endpoints }}
         server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
     {{ end }}
@@ -587,7 +587,7 @@ stream {
         listen                  {{ $udpServer.Port }} udp;
         {{ if $IsIPV6Enabled }}listen                  [::]:{{ $udpServer.Port }} udp;{{ end }}
         proxy_responses         1;
-        proxy_pass              udp-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }};
+        proxy_pass              udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }};
     }
     {{ end }}
 }

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -319,4 +319,6 @@ type L4Backend struct {
 	Name      string             `json:"name"`
 	Namespace string             `json:"namespace"`
 	Protocol  api.Protocol       `json:"protocol"`
+	// +optional
+	UseProxyProtocol bool `json:"useProxyProtocol"`
 }


### PR DESCRIPTION
fixes #659 

Example:
```yaml
apiVersion: v1
data:
  "9000": default/http-svc:80:PROXY
kind: ConfigMap
metadata:
  name: ingress-controller-tcp
  namespace: kube-system
```

```console
     # TCP services
+    upstream tcp-default-http-svc-80 {
+        server                  172.17.0.3:8080;
+        server                  172.17.0.4:8080;
+    }
+
+    server {
+        listen                  9000 proxy_protocol;
+        listen                  [::]:9000 proxy_protocol;
+        proxy_pass              tcp-default-http-svc-80;
+    }
```