### PR TITLE
Sets parameters for a shared memory zone of limit_conn_zone

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -444,6 +444,9 @@ The default mime type list to compress is: `application/atom+xml application/jav
 **worker-processes:** Sets the number of [worker processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes). The default of "auto" means number of available CPU cores.
 
 
+**limit-conn-zone-variable:** Sets parameters for a shared memory zone that will keep states for various keys of [limit_conn_zone](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone). The default of "$binary_remote_addr" variable’s size is always 4 bytes for IPv4 addresses or 16 bytes for IPv6 addresses.
+
+
 ### Default configuration options
 
 The following table shows the options, the default value and a description.
@@ -496,6 +499,7 @@ The following table shows the options, the default value and a description.
 |vts-status-zone-size|10m|
 |whitelist-source-range|permit all|
 |worker-processes|number of CPUs|
+|limit-conn-zone-variable|$binary_remote_addr|
 
 
 ### Websockets

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -73,6 +73,10 @@ const (
 
 	// Default setting for load balancer algorithm
 	defaultLoadBalancerAlgorithm = "least_conn"
+
+	// Parameters for a shared memory zone that will keep states for various keys.
+	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
+	defaultLimitConnZoneVariable = "$binary_remote_addr"
 )
 
 // Configuration represents the content of nginx.conf file
@@ -298,6 +302,10 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
 	// Default: 0 (disabled)
 	UpstreamKeepaliveConnections int `json:"upstream-keepalive-connections,omitempty"`
+
+	// Sets the maximum size of the variables hash table.
+	// http://nginx.org/en/docs/http/ngx_http_map_module.html#variables_hash_max_size
+	LimitConnZoneVariable string `json:"limit-conn-zone-variable,omitempty"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -360,6 +368,7 @@ func NewDefault() Configuration {
 			SkipAccessLogURLs:    []string{},
 		},
 		UpstreamKeepaliveConnections: 0,
+		LimitConnZoneVariable: defaultLimitConnZoneVariable,
 	}
 
 	if glog.V(5) {

--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -328,7 +328,7 @@ func buildProxyPass(host string, b interface{}, loc interface{}) string {
 // buildRateLimitZones produces an array of limit_conn_zone in order to allow
 // rate limiting of request. Each Ingress rule could have up to two zones, one
 // for connection limit by IP address and other for limiting request per second
-func buildRateLimitZones(input interface{}) []string {
+func buildRateLimitZones(variable string, input interface{}) []string {
 	zones := sets.String{}
 
 	servers, ok := input.([]*ingress.Server)
@@ -340,7 +340,8 @@ func buildRateLimitZones(input interface{}) []string {
 		for _, loc := range server.Locations {
 
 			if loc.RateLimit.Connections.Limit > 0 {
-				zone := fmt.Sprintf("limit_conn_zone $binary_remote_addr zone=%v:%vm;",
+				zone := fmt.Sprintf("limit_conn_zone %v zone=%v:%vm;",
+					variable,
 					loc.RateLimit.Connections.Name,
 					loc.RateLimit.Connections.SharedSize)
 				if !zones.Has(zone) {
@@ -349,7 +350,8 @@ func buildRateLimitZones(input interface{}) []string {
 			}
 
 			if loc.RateLimit.RPS.Limit > 0 {
-				zone := fmt.Sprintf("limit_req_zone $binary_remote_addr zone=%v:%vm rate=%vr/s;",
+				zone := fmt.Sprintf("limit_req_zone %v zone=%v:%vm rate=%vr/s;",
+					variable,
 					loc.RateLimit.RPS.Name,
 					loc.RateLimit.RPS.SharedSize,
 					loc.RateLimit.RPS.Limit)

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -280,7 +280,7 @@ http {
 
     {{/* build all the required rate limit zones. Each annotation requires a dedicated zone */}}
     {{/* 1MB -> 16 thousand 64-byte states or about 8 thousand 128-byte states */}}
-    {{ range $zone := (buildRateLimitZones .Servers) }}
+    {{ range $zone := (buildRateLimitZones $cfg.LimitConnZoneVariable .Servers) }}
     {{ $zone }}
     {{ end }}
 

--- a/controllers/nginx/test/data/config.json
+++ b/controllers/nginx/test/data/config.json
@@ -39,7 +39,8 @@
 		"useGzip": true,
 		"useHttp2": true,
 		"vtsStatusZoneSize": "10m",
-		"workerProcesses": 1
+		"workerProcesses": 1,
+		"limitConnZoneVariable": "$the_real_ip"
 	},
 	"customErrors": true,
 	"defResolver": "",


### PR DESCRIPTION
Sets parameters for a shared memory zone that will keep states for various keys of [limit_conn_zone](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone)