### PR TITLE
fix nginx version to 1.13.3 to fix integer overflow

### DIFF
--- a/images/nginx-slim/Makefile
+++ b/images/nginx-slim/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG = 0.20
+TAG = 0.21
 REGISTRY = gcr.io/google_containers
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm ppc64le

--- a/images/nginx-slim/build.sh
+++ b/images/nginx-slim/build.sh
@@ -17,7 +17,7 @@
 
 set -e
 
-export NGINX_VERSION=1.13.2
+export NGINX_VERSION=1.13.3
 export NDK_VERSION=0.3.0
 export VTS_VERSION=0.1.15
 export SETMISC_VERSION=0.31
@@ -77,7 +77,7 @@ apt-get update && apt-get install --no-install-recommends -y \
   linux-headers-generic || exit 1
 
 # download, verify and extract the source files
-get_src d77f234d14989d273a363f570e1d892395c006fef2ec04789be90f41a1919b70 \
+get_src 5b73f98004c302fb8e4a172abf046d9ce77739a82487e4873b39f9b0dcbb0d72 \
         "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
 get_src 88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619 \


### PR DESCRIPTION
Due to http://nginx.org/en/security_advisories.html

This increases the version of nginx to 1.13.3