### PR TITLE
[GLBC] Minor cleanup for logging & future changes

### DIFF
--- a/controllers/gce/backends/backends.go
+++ b/controllers/gce/backends/backends.go
@@ -443,6 +443,7 @@ func (b *Backends) Status(name string) string {
 }
 
 func applyLegacyHCToHC(existing *compute.HttpHealthCheck, hc *healthchecks.HealthCheck) {
+	hc.Description = existing.Description
 	hc.CheckIntervalSec = existing.CheckIntervalSec
 	hc.HealthyThreshold = existing.HealthyThreshold
 	hc.Host = existing.Host

--- a/controllers/gce/backends/backends_test.go
+++ b/controllers/gce/backends/backends_test.go
@@ -136,6 +136,7 @@ func TestHealthCheckMigration(t *testing.T) {
 		Name:               namer.BeName(p.Port),
 		RequestPath:        "/my-healthz-path",
 		Host:               "k8s.io",
+		Description:        "My custom HC",
 		UnhealthyThreshold: 30,
 		CheckIntervalSec:   40,
 	}
@@ -154,7 +155,8 @@ func TestHealthCheckMigration(t *testing.T) {
 	if hc.RequestPath != legacyHC.RequestPath ||
 		hc.Host != legacyHC.Host ||
 		hc.UnhealthyThreshold != legacyHC.UnhealthyThreshold ||
-		hc.CheckIntervalSec != legacyHC.CheckIntervalSec {
+		hc.CheckIntervalSec != legacyHC.CheckIntervalSec ||
+		hc.Description != legacyHC.Description {
 		t.Fatalf("Expected newer health check to have identical settings to legacy health check. Legacy: %+v, New: %+v", legacyHC, hc)
 	}
 }

--- a/controllers/gce/loadbalancers/loadbalancers.go
+++ b/controllers/gce/loadbalancers/loadbalancers.go
@@ -163,7 +163,7 @@ func (l *L7s) Delete(name string) error {
 
 // Sync loadbalancers with the given runtime info from the controller.
 func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
-	glog.V(3).Infof("Creating loadbalancers %+v", lbs)
+	glog.V(3).Infof("Syncing loadbalancers %v", lbs)
 
 	if len(lbs) != 0 {
 		// Lazily create a default backend so we don't tax users who don't care
@@ -255,6 +255,11 @@ type L7RuntimeInfo struct {
 	// The name of a Global Static IP. If specified, the IP associated with
 	// this name is used in the Forwarding Rules for this loadbalancer.
 	StaticIPName string
+}
+
+// String returns the load balancer name
+func (l *L7RuntimeInfo) String() string {
+	return l.Name
 }
 
 // L7 represents a single L7 loadbalancer.
@@ -757,7 +762,6 @@ func (l *L7) UpdateUrlMap(ingressRules utils.GCEURLMap) error {
 	if l.um == nil {
 		return fmt.Errorf("cannot add url without an urlmap")
 	}
-	glog.V(3).Infof("Updating urlmap for l7 %v", l.Name)
 
 	// All UrlMaps must have a default backend. If the Ingress has a default
 	// backend, it applies to all host rules as well as to the urlmap itself.
@@ -807,7 +811,8 @@ func (l *L7) UpdateUrlMap(ingressRules utils.GCEURLMap) error {
 		glog.Infof("UrlMap for l7 %v is unchanged", l.Name)
 		return nil
 	}
-	glog.Infof("Updating url map: %+v", ingressRules)
+
+	glog.V(3).Infof("Updating URLMap: %q", l.Name)
 	um, err := l.cloud.UpdateUrlMap(l.um)
 	if err != nil {
 		return err

--- a/controllers/gce/utils/utils.go
+++ b/controllers/gce/utils/utils.go
@@ -191,7 +191,6 @@ func (n *Namer) ParseName(name string) *NameComponents {
 // NameBelongsToCluster checks if a given name is tagged with this cluster's UID.
 func (n *Namer) NameBelongsToCluster(name string) bool {
 	if !strings.HasPrefix(name, "k8s-") {
-		glog.V(4).Infof("%v not part of cluster", name)
 		return false
 	}
 	parts := strings.Split(name, clusterNameDelimiter)
@@ -203,7 +202,6 @@ func (n *Namer) NameBelongsToCluster(name string) bool {
 		return false
 	}
 	if len(parts) > 2 {
-		glog.Warningf("Too many parts to name %v, ignoring", name)
 		return false
 	}
 	return parts[1] == clusterName


### PR DESCRIPTION
Changes
* Copies over description from legacy health check
* Log loadbalancer name instead of memory address
* Remove superfluous log messages about non-K8s backend services. 