### PR TITLE
Release nginx-slim 0.21

### DIFF
--- a/images/nginx-slim/Makefile
+++ b/images/nginx-slim/Makefile
@@ -25,7 +25,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=gcr.io/google_containers/ubuntu-slim-$(ARCH):0.12
+BASEIMAGE?=gcr.io/google_containers/ubuntu-slim-$(ARCH):0.13
 
 ifeq ($(ARCH),arm)
         QEMUARCH=arm


### PR DESCRIPTION
This releases is required to address CVE-2017-7529 - http://nginx.org/en/security_advisories.html

Requires #958 