### PR TITLE
Add sort-backends command line option

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -145,6 +145,7 @@ type Configuration struct {
 	UpdateStatus           bool
 	ElectionID             string
 	UpdateStatusOnShutdown bool
+	SortBackends           bool
 }
 
 // newIngressController creates an Ingress controller
@@ -736,6 +737,9 @@ func (ic *GenericController) getBackendServers() ([]*ingress.Backend, []*ingress
 		}
 		aUpstreams = append(aUpstreams, value)
 	}
+	if ic.cfg.SortBackends {
+		sort.Sort(ingress.BackendByNameServers(aUpstreams))
+	}
 
 	aServers := make([]*ingress.Server, 0, len(servers))
 	for _, value := range servers {
@@ -885,15 +889,20 @@ func (ic *GenericController) serviceEndpoints(svcKey, backendPort string,
 				glog.Warningf("service %v does not have any active endpoints", svcKey)
 			}
 
+			if ic.cfg.SortBackends {
+				sort.Sort(ingress.EndpointByAddrPort(endps))
+			}
 			upstreams = append(upstreams, endps...)
 			break
 		}
 	}
 
-	rand.Seed(time.Now().UnixNano())
-	for i := range upstreams {
-		j := rand.Intn(i + 1)
-		upstreams[i], upstreams[j] = upstreams[j], upstreams[i]
+	if !ic.cfg.SortBackends {
+		rand.Seed(time.Now().UnixNano())
+		for i := range upstreams {
+			j := rand.Intn(i + 1)
+			upstreams[i], upstreams[j] = upstreams[j], upstreams[i]
+		}
 	}
 
 	return upstreams, nil

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -93,6 +93,9 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		UpdateStatusOnShutdown = flags.Bool("update-status-on-shutdown", true, `Indicates if the 
 		ingress controller should update the Ingress status IP/hostname when the controller 
 		is being stopped. Default is true`)
+
+		SortBackends = flags.Bool("sort-backends", false,
+			`Defines if backends and it's endpoints should be sorted`)
 	)
 
 	flags.AddGoFlagSet(flag.CommandLine)
@@ -169,6 +172,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		Backend:                 backend,
 		ForceNamespaceIsolation: *forceIsolation,
 		UpdateStatusOnShutdown:  *UpdateStatusOnShutdown,
+		SortBackends:            *SortBackends,
 	}
 
 	ic := newIngressController(config)


### PR DESCRIPTION
This option allows to create a predictable config file in order to compare before/after when developing and debugging. If not specified will use the current approach.