### PR TITLE
Support for proxy_headers_hash_bucket_size and proxy_headers_hash_max_size

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -365,6 +365,13 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket
 **server-name-hash-max-size:** Sets the maximum size of the [server names hash tables](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) used in server names, map directive’s values, MIME types, names of request header strings, etc.
 http://nginx.org/en/docs/hash.html
 
+**proxy-headers-hash-bucket-size:** Sets the size of the bucket for the proxy headers hash tables.
+http://nginx.org/en/docs/hash.html
+https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_bucket_size
+
+**proxy-headers-hash-max-size:** Sets the maximum size of the proxy headers hash tables.
+http://nginx.org/en/docs/hash.html
+https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_max_size
 
 **server-tokens:** Send NGINX Server header in responses and display NGINX version in error pages. Enabled by default.
 

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -218,6 +218,16 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size
 	ServerNameHashBucketSize int `json:"server-name-hash-bucket-size,omitempty"`
 
+	// Size of the bucket for the proxy headers hash tables
+	// http://nginx.org/en/docs/hash.html
+	// https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_max_size
+	ProxyHeadersHashMaxSize int `json:"proxy-headers-hash-max-size,omitempty"`
+
+	// Maximum size of the bucket for the proxy headers hash tables
+	// http://nginx.org/en/docs/hash.html
+	// https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_bucket_size
+	ProxyHeadersHashBucketSize int `json:"proxy-headers-hash-bucket-size,omitempty"`
+
 	// Enables or disables emitting nginx version in error messages and in the “Server” response header field.
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
 	// Default: true
@@ -340,6 +350,8 @@ func NewDefault() Configuration {
 		MapHashBucketSize:        64,
 		ProxyRealIPCIDR:          defIPCIDR,
 		ServerNameHashMaxSize:    1024,
+		ProxyHeadersHashMaxSize:  512,
+		ProxyHeadersHashBucketSize: 64,
 		ShowServerTokens:         true,
 		SSLBufferSize:            sslBufferSize,
 		SSLCiphers:               sslCiphers,

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -76,6 +76,9 @@ http {
     server_names_hash_bucket_size   {{ $cfg.ServerNameHashBucketSize }};
     map_hash_bucket_size            {{ $cfg.MapHashBucketSize }};
 
+    proxy_headers_hash_max_size     {{ $cfg.ProxyHeadersHashMaxSize }};
+    proxy_headers_hash_bucket_size  {{ $cfg.ProxyHeadersHashBucketSize }};
+
     variables_hash_bucket_size      {{ $cfg.VariablesHashBucketSize }};
     variables_hash_max_size         {{ $cfg.VariablesHashMaxSize }};
 


### PR DESCRIPTION
This makes proxy_headers_hash_bucket_size and proxy_headers_hash_max_size configurable in the nginx controller.

See https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_bucket_size and https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_max_size