### PR TITLE
Fix error checking for pod name & NS

### DIFF
--- a/core/pkg/k8s/main.go
+++ b/core/pkg/k8s/main.go
@@ -117,7 +117,7 @@ func GetPodDetails(kubeClient clientset.Interface) (*PodInfo, error) {
 	podName := os.Getenv("POD_NAME")
 	podNs := os.Getenv("POD_NAMESPACE")
 
-	if podName == "" && podNs == "" {
+	if podName == "" || podNs == "" {
 		return nil, fmt.Errorf("unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable")
 	}
 

--- a/core/pkg/k8s/main_test.go
+++ b/core/pkg/k8s/main_test.go
@@ -297,11 +297,27 @@ func TestGetPodDetails(t *testing.T) {
 		t.Errorf("expected an error but returned nil")
 	}
 
-	// POD not exist
-	os.Setenv("POD_NAME", "testpod")
+	// POD_NAME not exist
+	os.Setenv("POD_NAME", "")
 	os.Setenv("POD_NAMESPACE", api.NamespaceDefault)
 	_, err2 := GetPodDetails(testclient.NewSimpleClientset())
 	if err2 == nil {
+		t.Errorf("expected an error but returned nil")
+	}
+
+	// POD_NAMESPACE not exist
+	os.Setenv("POD_NAME", "testpod")
+	os.Setenv("POD_NAMESPACE", "")
+	_, err3 := GetPodDetails(testclient.NewSimpleClientset())
+	if err3 == nil {
+		t.Errorf("expected an error but returned nil")
+	}
+
+	// POD not exist
+	os.Setenv("POD_NAME", "testpod")
+	os.Setenv("POD_NAMESPACE", api.NamespaceDefault)
+	_, err4 := GetPodDetails(testclient.NewSimpleClientset())
+	if err4 == nil {
 		t.Errorf("expected an error but returned nil")
 	}
 
@@ -331,8 +347,8 @@ func TestGetPodDetails(t *testing.T) {
 			},
 		}}})
 
-	epi, err3 := GetPodDetails(fkClient)
-	if err3 != nil {
+	epi, err5 := GetPodDetails(fkClient)
+	if err5 != nil {
 		t.Errorf("expected a PodInfo but returned error")
 		return
 	}


### PR DESCRIPTION
Previously it would just check if POD_NAME *or* POD_NAMESPACE was set, which
could lead to very bizarre failure modes.