### PR TITLE
check number of servers in configuration comparator

### DIFF
--- a/core/pkg/ingress/types_equals.go
+++ b/core/pkg/ingress/types_equals.go
@@ -64,6 +64,10 @@ func (c1 *Configuration) Equal(c2 *Configuration) bool {
 		}
 	}
 
+	if len(c1.Servers) != len(c2.Servers) {
+		return false
+	}
+
 	for _, c1s := range c1.Servers {
 		found := false
 		for _, c2s := range c2.Servers {


### PR DESCRIPTION
Resolves #945 

Fix for the problem when Nginx is not synced & reloaded when you update an ingress with more than one host rule. The condition to check if the old and new configuration is unchanged returned `true` always, as the check for `len(servers)` was not there.