### PR TITLE
Release nginx 0.9.0-beta.11

### DIFF
--- a/controllers/nginx/Changelog.md
+++ b/controllers/nginx/Changelog.md
@@ -1,5 +1,35 @@
 Changelog
 
+Changelog
+
+### 0.9-beta.11
+
+**Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11`
+
+Fixes NGINX [CVE-2017-7529](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7529)
+
+*Changes:*
+
+- [X] [#659](https://github.com/kubernetes/ingress/pull/659) [nginx] TCP configmap should allow listen proxy_protocol per service
+- [X] [#730](https://github.com/kubernetes/ingress/pull/730) Add support for add_headers
+- [X] [#808](https://github.com/kubernetes/ingress/pull/808) HTTP->HTTPS redirect does not work with use-proxy-protocol: "true"
+- [X] [#921](https://github.com/kubernetes/ingress/pull/921) Make proxy-real-ip-cidr a comma separated list
+- [X] [#930](https://github.com/kubernetes/ingress/pull/930) Add support for proxy protocol in TCP services
+- [X] [#933](https://github.com/kubernetes/ingress/pull/933) Lint code
+- [X] [#937](https://github.com/kubernetes/ingress/pull/937) Fix lint code errors
+- [X] [#940](https://github.com/kubernetes/ingress/pull/940) Sets parameters for a shared memory zone of limit_conn_zone
+- [X] [#949](https://github.com/kubernetes/ingress/pull/949) fix nginx version to 1.13.3 to fix integer overflow
+- [X] [#956](https://github.com/kubernetes/ingress/pull/956) Simplify handling of ssl certificates
+- [X] [#958](https://github.com/kubernetes/ingress/pull/958) Release ubuntu-slim:0.13
+- [X] [#959](https://github.com/kubernetes/ingress/pull/959) Release nginx-slim 0.21
+- [X] [#960](https://github.com/kubernetes/ingress/pull/960) Update nginx in ingress controller
+- [X] [#964](https://github.com/kubernetes/ingress/pull/964) Support for proxy_headers_hash_bucket_size and proxy_headers_hash_max_size
+- [X] [#966](https://github.com/kubernetes/ingress/pull/966) Fix error checking for pod name & NS
+- [X] [#967](https://github.com/kubernetes/ingress/pull/967) Fix runningAddresses typo
+- [X] [#968](https://github.com/kubernetes/ingress/pull/968) Fix missing hyphen in yaml for nginx RBAC example
+- [X] [#973](https://github.com/kubernetes/ingress/pull/973) check number of servers in configuration comparator
+
+
 ### 0.9-beta.10
 
 **Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10`

--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -3,7 +3,7 @@ all: push
 BUILDTAGS=
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
-TAG?=0.9.0-beta.10
+TAG?=0.9.0-beta.11
 REGISTRY?=gcr.io/google_containers
 GOOS?=linux
 DOCKER?=gcloud docker --

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,7 +259,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: ingress-nginx
         imagePullPolicy: Always
         ports:

--- a/examples/aws/nginx/nginx-ingress-controller.yaml
+++ b/examples/aws/nginx/nginx-ingress-controller.yaml
@@ -101,7 +101,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: ingress-nginx
         imagePullPolicy: Always
         ports:

--- a/examples/customization/configuration-snippets/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/configuration-snippets/nginx/nginx-ingress-controller.yaml
@@ -19,7 +19,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/custom-configuration/nginx/nginx-custom-configuration.yaml
+++ b/examples/customization/custom-configuration/nginx/nginx-custom-configuration.yaml
@@ -22,7 +22,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/custom-errors/nginx/rc-custom-errors.yaml
+++ b/examples/customization/custom-errors/nginx/rc-custom-errors.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-lb
         imagePullPolicy: Always
         readinessProbe:

--- a/examples/customization/custom-headers/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/custom-headers/nginx/nginx-ingress-controller.yaml
@@ -19,7 +19,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/custom-template/custom-template.yaml
+++ b/examples/customization/custom-template/custom-template.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-lb
         imagePullPolicy: Always
         readinessProbe:

--- a/examples/customization/custom-vts-metrics/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/custom-vts-metrics/nginx/nginx-ingress-controller.yaml
@@ -22,7 +22,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/customization/ssl-dh-param/nginx/nginx-ingress-controller.yaml
+++ b/examples/customization/ssl-dh-param/nginx/nginx-ingress-controller.yaml
@@ -19,7 +19,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
+++ b/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-lb
         readinessProbe:
           httpGet:

--- a/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
@@ -71,7 +71,7 @@ spec:
       hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/deployment/nginx/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/nginx-ingress-controller.yaml
@@ -22,7 +22,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/rbac/nginx/nginx-ingress-controller.yml
+++ b/examples/rbac/nginx/nginx-ingress-controller.yml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
           args:
              - /nginx-ingress-controller
              - --default-backend-service=default/default-http-backend

--- a/examples/scaling-deployment/nginx/nginx-ingress-deployment.yaml
+++ b/examples/scaling-deployment/nginx/nginx-ingress-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/static-ip/nginx/nginx-ingress-controller.yaml
+++ b/examples/static-ip/nginx/nginx-ingress-controller.yaml
@@ -18,7 +18,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:

--- a/examples/tcp/nginx/README.md
+++ b/examples/tcp/nginx/README.md
@@ -47,7 +47,7 @@ nginx-ingress-controller   1         1         1         3m
 $ kubectl -n kube-system describe rc nginx-ingress-controller
 Name:           nginx-ingress-controller
 Namespace:      kube-system
-Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
 Selector:       k8s-app=nginx-tcp-ingress-lb
 Labels:         k8s-app=nginx-ingress-lb
 Annotations:    <none>

--- a/examples/tcp/nginx/nginx-tcp-ingress-controller.yaml
+++ b/examples/tcp/nginx/nginx-tcp-ingress-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-tcp-ingress-lb
         readinessProbe:
           httpGet:

--- a/examples/tls-termination/elb-nginx/nginx-ingress-controller.yaml
+++ b/examples/tls-termination/elb-nginx/nginx-ingress-controller.yaml
@@ -105,7 +105,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.8
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: ingress-nginx
         imagePullPolicy: Always
         ports:

--- a/examples/udp/nginx/README.md
+++ b/examples/udp/nginx/README.md
@@ -53,7 +53,7 @@ nginx-udp-ingress-controller   1         1         1         13m
 $ kubectl -n kube-system describe rc nginx-udp-ingress-controller
 Name:           nginx-udp-ingress-controller
 Namespace:      kube-system
-Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+Image(s):       gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
 Selector:       k8s-app=nginx-udp-ingress-lb
 Labels:         k8s-app=nginx-udp-ingress-lb
 Annotations:    <none>

--- a/examples/udp/nginx/nginx-udp-ingress-controller.yaml
+++ b/examples/udp/nginx/nginx-udp-ingress-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-udp-ingress-lb
         readinessProbe:
           httpGet:


### PR DESCRIPTION
Temporal image: `quay.io/aledbf/nginx-ingress-controller:0.165`
