### PR TITLE
Add sort-backends command line option

### DIFF
--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -93,6 +93,9 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		UpdateStatusOnShutdown = flags.Bool("update-status-on-shutdown", true, `Indicates if the 
 		ingress controller should update the Ingress status IP/hostname when the controller 
 		is being stopped. Default is true`)
+
+		SortBackends = flags.Bool("sort-backends", false,
+			`Defines if backends and it's endpoints should be sorted`)
 	)
 
 	flags.AddGoFlagSet(flag.CommandLine)
@@ -169,6 +172,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		Backend:                 backend,
 		ForceNamespaceIsolation: *forceIsolation,
 		UpdateStatusOnShutdown:  *UpdateStatusOnShutdown,
+		SortBackends:            *SortBackends,
 	}
 
 	ic := newIngressController(config)


### PR DESCRIPTION
This option allows to create a predictable config file in order to compare before/after when developing and debugging. If not specified will use the current approach. Copy from #961 whose Travis CI failure was unreproducible on my local copy.