### PR TITLE
Add annotation to allow use of service ClusterIP for NGINX upstream.

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -57,6 +57,7 @@ The following annotations are supported:
 |[ingress.kubernetes.io/proxy-body-size](#custom-max-body-size)|string|
 |[ingress.kubernetes.io/rewrite-target](#rewrite)|URI|
 |[ingress.kubernetes.io/secure-backends](#secure-backends)|true or false|
+|[ingress.kubernetes.io/service-upstream](#service-upstream)|true or false|
 |[ingress.kubernetes.io/session-cookie-name](#cookie-affinity)|string|
 |[ingress.kubernetes.io/session-cookie-hash](#cookie-affinity)|string|
 |[ingress.kubernetes.io/ssl-redirect](#server-side-https-enforcement-through-redirect)|true or false|
@@ -213,6 +214,17 @@ This is possible thanks to the [ngx_stream_ssl_preread_module](https://nginx.org
 
 By default NGINX uses `http` to reach the services. Adding the annotation `ingress.kubernetes.io/secure-backends: "true"` in the Ingress rule changes the protocol to `https`.
 
+### Service Upstream
+
+By default the NGINX ingress controller uses a list of all endpoints (Pod IP/port) in the NGINX upstream configuration. This annotation disables that behavior and instead uses a single upstream in NGINX, the service's Cluster IP and port. This can be desirable for things like zero-downtime deployments as it reduces the need to reload NGINX configuration when Pods come up and down. See issue [#257](https://github.com/kubernetes/ingress/issues/257).
+
+
+#### Known Issues
+
+If the `service-upstream` annotation is specified the following things should be taken into consideration:
+
+* Sticky Sessions will not work as only round-robin load balancing is supported. 
+* The `proxy_next_upstream` directive will not have any effect meaning on error the request will not be dispatched to another upstream.
 
 ### Server-side HTTPS enforcement through redirect
 

--- a/core/pkg/ingress/annotations/serviceupstream/main.go
+++ b/core/pkg/ingress/annotations/serviceupstream/main.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceupstream
+
+import (
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/ingress/core/pkg/ingress/annotations/parser"
+)
+
+const (
+	annotationServiceUpstream = "ingress.kubernetes.io/service-upstream"
+)
+
+type serviceUpstream struct {
+}
+
+// NewParser creates a new serviceUpstream annotation parser
+func NewParser() parser.IngressAnnotation {
+	return serviceUpstream{}
+}
+
+func (s serviceUpstream) Parse(ing *extensions.Ingress) (interface{}, error) {
+	return parser.GetBoolAnnotation(annotationServiceUpstream, ing)
+}

--- a/core/pkg/ingress/annotations/serviceupstream/main_test.go
+++ b/core/pkg/ingress/annotations/serviceupstream/main_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceupstream
+
+import (
+	"testing"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	api "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func buildIngress() *extensions.Ingress {
+	defaultBackend := extensions.IngressBackend{
+		ServiceName: "default-backend",
+		ServicePort: intstr.FromInt(80),
+	}
+
+	return &extensions.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: extensions.IngressSpec{
+			Backend: &extensions.IngressBackend{
+				ServiceName: "default-backend",
+				ServicePort: intstr.FromInt(80),
+			},
+			Rules: []extensions.IngressRule{
+				{
+					Host: "foo.bar.com",
+					IngressRuleValue: extensions.IngressRuleValue{
+						HTTP: &extensions.HTTPIngressRuleValue{
+							Paths: []extensions.HTTPIngressPath{
+								{
+									Path:    "/foo",
+									Backend: defaultBackend,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestIngressAnnotationServiceUpstreamEnabled(t *testing.T) {
+	ing := buildIngress()
+
+	data := map[string]string{}
+	data[annotationServiceUpstream] = "true"
+	ing.SetAnnotations(data)
+
+	val, _ := NewParser().Parse(ing)
+	enabled, ok := val.(bool)
+	if !ok {
+		t.Errorf("expected a bool type")
+	}
+
+	if !enabled {
+		t.Errorf("expected annotation value to be true, got false")
+	}
+}
+
+func TestIngressAnnotationServiceUpstreamSetFalse(t *testing.T) {
+	ing := buildIngress()
+
+	// Test with explicitly set to false
+	data := map[string]string{}
+	data[annotationServiceUpstream] = "false"
+	ing.SetAnnotations(data)
+
+	val, _ := NewParser().Parse(ing)
+	enabled, ok := val.(bool)
+	if !ok {
+		t.Errorf("expected a bool type")
+	}
+
+	if enabled {
+		t.Errorf("expected annotation value to be false, got true")
+	}
+
+	// Test with no annotation specified, should default to false
+	data = map[string]string{}
+	ing.SetAnnotations(data)
+
+	val, _ = NewParser().Parse(ing)
+	enabled, ok = val.(bool)
+	if !ok {
+		t.Errorf("expected a bool type")
+	}
+
+	if enabled {
+		t.Errorf("expected annotation value to be false, got true")
+	}
+}

--- a/core/pkg/ingress/controller/annotations.go
+++ b/core/pkg/ingress/controller/annotations.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/annotations/ratelimit"
 	"k8s.io/ingress/core/pkg/ingress/annotations/rewrite"
 	"k8s.io/ingress/core/pkg/ingress/annotations/secureupstream"
+	"k8s.io/ingress/core/pkg/ingress/annotations/serviceupstream"
 	"k8s.io/ingress/core/pkg/ingress/annotations/sessionaffinity"
 	"k8s.io/ingress/core/pkg/ingress/annotations/snippet"
 	"k8s.io/ingress/core/pkg/ingress/annotations/sslpassthrough"
@@ -64,6 +65,7 @@ func newAnnotationExtractor(cfg extractorConfig) annotationExtractor {
 			"RateLimit":            ratelimit.NewParser(),
 			"Redirect":             rewrite.NewParser(cfg),
 			"SecureUpstream":       secureupstream.NewParser(cfg),
+			"ServiceUpstream":      serviceupstream.NewParser(),
 			"SessionAffinity":      sessionaffinity.NewParser(),
 			"SSLPassthrough":       sslpassthrough.NewParser(),
 			"ConfigurationSnippet": snippet.NewParser(),
@@ -104,7 +106,13 @@ const (
 	healthCheck     = "HealthCheck"
 	sslPassthrough  = "SSLPassthrough"
 	sessionAffinity = "SessionAffinity"
+	serviceUpstream = "ServiceUpstream"
 )
+
+func (e *annotationExtractor) ServiceUpstream(ing *extensions.Ingress) bool {
+	val, _ := e.annotations[serviceUpstream].Parse(ing)
+	return val.(bool)
+}
 
 func (e *annotationExtractor) SecureUpstream(ing *extensions.Ingress) *secureupstream.Secure {
 	val, err := e.annotations[secureUpstream].Parse(ing)


### PR DESCRIPTION
This change adds a new annotation `ingress.kubernetes.io/service-upstream` that when set to true, uses a service's Cluster IP and port as the single upstream server, rather than the full list of service endpoints. This may address #257. 

There are now no NGINX configuration reloads necessary when a service's pods come and go. 

This helps with things like zero-downtime deployments and other issues arising from NGINX configuration reloads for upstream server changes.