### PR TITLE
echoheaders: nginx-slim:0.21 and release echoserver:1.7

### DIFF
--- a/images/echoheaders/Dockerfile
+++ b/images/echoheaders/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-slim:0.18
+FROM gcr.io/google_containers/nginx-slim:0.21
 
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD template.lua /usr/local/share/lua/5.1/

--- a/images/echoheaders/Makefile
+++ b/images/echoheaders/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # TAG 0.0 shouldn't clobber any release builds
-TAG = 1.6
+TAG = 1.7
 PREFIX = gcr.io/google_containers/echoserver
 
 container:


### PR DESCRIPTION
echoserver fell a few versions behind

Bumping to pick up the the new nginx-slim and releasing `echoserver:1.7`