### PR TITLE
Fix the sed command to work on macOS

### DIFF
--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -7,6 +7,12 @@ TAG?=0.9.0-beta.11
 REGISTRY?=gcr.io/google_containers
 GOOS?=linux
 DOCKER?=gcloud docker --
+SED_I?=sed -i
+GOHOSTOS ?= $(shell go env GOHOSTOS)
+
+ifeq ($(GOHOSTOS),darwin)
+  SED_I=sed -i ''
+endif
 
 REPO_INFO=$(shell git config --get remote.origin.url)
 
@@ -65,19 +71,19 @@ all-push: $(addprefix sub-push-,$(ALL_ARCH))
 container: .container-$(ARCH)
 .container-$(ARCH):
 	cp -r ./* $(TEMP_DIR)
-	cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' rootfs/Dockerfile
-	cd $(TEMP_DIR) && sed -i "s|QEMUARCH|$(QEMUARCH)|g" rootfs/Dockerfile
-	cd $(TEMP_DIR) && sed -i "s|DUMB_ARCH|$(DUMB_ARCH)|g" rootfs/Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) 's|BASEIMAGE|$(BASEIMAGE)|g' rootfs/Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) "s|QEMUARCH|$(QEMUARCH)|g" rootfs/Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) "s|DUMB_ARCH|$(DUMB_ARCH)|g" rootfs/Dockerfile
 
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
-	cd $(TEMP_DIR) && sed -i "/CROSS_BUILD_/d" rootfs/Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) "/CROSS_BUILD_/d" rootfs/Dockerfile
 else
 	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
 	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
 	$(DOCKER) run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)/rootfs
-	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" rootfs/Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) "s/CROSS_BUILD_//g" rootfs/Dockerfile
 endif
 
 	$(DOCKER) build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)/rootfs


### PR DESCRIPTION
The `sed -i` doesn't work on macOS, it requires a zero-length extension. So use `sed -i ''` on macOS.