### PR TITLE
examples/nginx/rbac: Give access to own namespace

### DIFF
--- a/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
+++ b/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
@@ -73,6 +73,7 @@ rules:
       - configmaps
       - pods
       - secrets
+      - namespaces
     verbs:
       - get
   - apiGroups:


### PR DESCRIPTION
Even with `--force-namespace-isolation`, nginx-ingress-controller still queries for it's own namespace, so give it access to querying namespaces within it's namespace in the nginx-ingress-role.