### PR TITLE
External Nginx Ingress Controller

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -9,3 +9,4 @@ This is a non-comprehensive list of existing ingress controllers.
 * [AWS Application Load Balancer Ingress Controller](https://github.com/coreos/alb-ingress-controller)
 * [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller)
 * [Voyager: HAProxy Ingress Controller](https://github.com/appscode/voyager)
+* [External Nginx Ingress Controller](https://github.com/unibet/ext_nginx)


### PR DESCRIPTION
A nginx ingress controller for use outside a kubernetes cluster.