### PR TITLE
[WIP] Change syncSecret approach

### DIFF
--- a/core/pkg/ingress/controller/backend_ssl.go
+++ b/core/pkg/ingress/controller/backend_ssl.go
@@ -24,11 +24,9 @@ import (
 	"github.com/golang/glog"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/ingress/core/pkg/ingress"
-	"k8s.io/ingress/core/pkg/ingress/annotations/parser"
 	"k8s.io/ingress/core/pkg/net/ssl"
 )
 
@@ -109,26 +107,6 @@ func (ic *GenericController) getPemCertificate(secretName string) (*ingress.SSLC
 	s.Name = secret.Name
 	s.Namespace = secret.Namespace
 	return s, nil
-}
-
-// secrReferenced checks if a secret is referenced or not by one or more Ingress rules
-func (ic *GenericController) secrReferenced(name, namespace string) bool {
-	for _, ingIf := range ic.ingLister.Store.List() {
-		ing := ingIf.(*extensions.Ingress)
-		str, err := parser.GetStringAnnotation("ingress.kubernetes.io/auth-tls-secret", ing)
-		if err == nil && str == fmt.Sprintf("%v/%v", namespace, name) {
-			return true
-		}
-		if ing.Namespace != namespace {
-			continue
-		}
-		for _, tls := range ing.Spec.TLS {
-			if tls.SecretName == name {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // sslCertTracker holds a store of referenced Secrets in Ingress rules

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -214,13 +214,6 @@ func newIngressController(config *Configuration) *GenericController {
 	}
 
 	secrEventHandler := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			sec := obj.(*api.Secret)
-			key := fmt.Sprintf("%v/%v", sec.Namespace, sec.Name)
-			if ic.secrReferenced(sec.Namespace, sec.Name) {
-				ic.syncSecret(key)
-			}
-		},
 		UpdateFunc: func(old, cur interface{}) {
 			if !reflect.DeepEqual(old, cur) {
 				sec := cur.(*api.Secret)

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -1097,6 +1097,10 @@ func (ic *GenericController) createServers(data []interface{},
 			key := fmt.Sprintf("%v/%v", ing.Namespace, tlsSecretName)
 			bc, exists := ic.sslCertTracker.Get(key)
 			if !exists {
+				ic.syncSecret(key)
+				bc, exists = ic.sslCertTracker.Get(key)
+			}
+			if !exists {
 				glog.Infof("ssl certificate \"%v\" does not exist in local store", key)
 				continue
 			}


### PR DESCRIPTION
`backend_ssl/secrReferenced` is being used to check if a secret is used by `auth-tls-secret` annotation and `spec.TLS attribute`. This list goes beyond these two attributes, eg: `auth-secret`, `secure-verify-ca-secret` and some configmap options should also be checked. This list should grow. This was implemented on #991 .

IOW the current (without this PR) behavior is try to guess when a secret should be added, which is not working if the secret is used eg on `auth-secret` annotation.

The PR implementation is half of the way to create a facade to find secrets. I added the only missing `ic.syncSecret()` I found on my tests. This might be evolved to a single func that do this job (try/sync/try again). This PR works on my local env.

Another approach is add every single secret without trying to guess if it is used or not.

What about these strategies?