### PR TITLE
Change missing secret name log level to V(3)

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -1088,7 +1088,7 @@ func (ic *GenericController) createServers(data []interface{},
 			}
 
 			if tlsSecretName == "" {
-				glog.Warningf("host %v is listed on tls section but secretName is empty. Using default cert", host)
+				glog.V(3).Infof("host %v is listed on tls section but secretName is empty. Using default cert", host)
 				servers[host].SSLCertificate = defaultPemFileName
 				servers[host].SSLPemChecksum = defaultPemSHA
 				continue


### PR DESCRIPTION
This is a proposal of changing a log entry from warning to V(3).Info. The motivation of this change is that a missing secret name on Spec.TLS is a valid configuration.