### PR TITLE
GCE: Update cloud calls for API changes

### DIFF
--- a/controllers/gce/instances/fakes.go
+++ b/controllers/gce/instances/fakes.go
@@ -81,10 +81,11 @@ func (f *FakeInstanceGroups) GetInstanceGroup(name, zone string) (*compute.Insta
 }
 
 // CreateInstanceGroup fakes instance group creation.
-func (f *FakeInstanceGroups) CreateInstanceGroup(name, zone string) (*compute.InstanceGroup, error) {
-	newGroup := &compute.InstanceGroup{Name: name, SelfLink: name, Zone: zone}
-	f.instanceGroups = append(f.instanceGroups, newGroup)
-	return newGroup, nil
+func (f *FakeInstanceGroups) CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error {
+	ig.SelfLink = ig.Name
+	ig.Zone = zone
+	f.instanceGroups = append(f.instanceGroups, ig)
+	return nil
 }
 
 // DeleteInstanceGroup fakes instance group deletion.

--- a/controllers/gce/instances/instances.go
+++ b/controllers/gce/instances/instances.go
@@ -77,7 +77,10 @@ func (i *Instances) AddInstanceGroup(name string, port int64) ([]*compute.Instan
 		var err error
 		if ig == nil {
 			glog.Infof("Creating instance group %v in zone %v", name, zone)
-			ig, err = i.cloud.CreateInstanceGroup(name, zone)
+			if err = i.cloud.CreateInstanceGroup(&compute.InstanceGroup{Name: name}, zone); err != nil {
+				return nil, nil, err
+			}
+			ig, err = i.cloud.GetInstanceGroup(name, zone)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/controllers/gce/instances/interfaces.go
+++ b/controllers/gce/instances/interfaces.go
@@ -45,7 +45,7 @@ type NodePool interface {
 // InstanceGroups is an interface for managing gce instances groups, and the instances therein.
 type InstanceGroups interface {
 	GetInstanceGroup(name, zone string) (*compute.InstanceGroup, error)
-	CreateInstanceGroup(name, zone string) (*compute.InstanceGroup, error)
+	CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error
 	DeleteInstanceGroup(name, zone string) error
 
 	// TODO: Refactor for modulatiry.

--- a/controllers/gce/loadbalancers/fakes.go
+++ b/controllers/gce/loadbalancers/fakes.go
@@ -114,21 +114,14 @@ func (f *FakeLoadBalancers) GetGlobalForwardingRule(name string) (*compute.Forwa
 }
 
 // CreateGlobalForwardingRule fakes forwarding rule creation.
-func (f *FakeLoadBalancers) CreateGlobalForwardingRule(proxyLink, ip, name, portRange string) (*compute.ForwardingRule, error) {
+func (f *FakeLoadBalancers) CreateGlobalForwardingRule(rule *compute.ForwardingRule) error {
 	f.calls = append(f.calls, "CreateGlobalForwardingRule")
-	if ip == "" {
-		ip = fmt.Sprintf(testIPManager.ip())
+	if rule.IPAddress == "" {
+		rule.IPAddress = fmt.Sprintf(testIPManager.ip())
 	}
-	rule := &compute.ForwardingRule{
-		Name:       name,
-		IPAddress:  ip,
-		Target:     proxyLink,
-		PortRange:  portRange,
-		IPProtocol: "TCP",
-		SelfLink:   name,
-	}
+	rule.SelfLink = rule.Name
 	f.Fw = append(f.Fw, rule)
-	return rule, nil
+	return nil
 }
 
 // SetProxyForGlobalForwardingRule fakes setting a global forwarding rule.
@@ -181,27 +174,23 @@ func (f *FakeLoadBalancers) GetUrlMap(name string) (*compute.UrlMap, error) {
 }
 
 // CreateUrlMap fakes url-map creation.
-func (f *FakeLoadBalancers) CreateUrlMap(backend *compute.BackendService, name string) (*compute.UrlMap, error) {
+func (f *FakeLoadBalancers) CreateUrlMap(urlMap *compute.UrlMap) error {
 	f.calls = append(f.calls, "CreateUrlMap")
-	urlMap := &compute.UrlMap{
-		Name:           name,
-		DefaultService: backend.SelfLink,
-		SelfLink:       f.umName(),
-	}
+	urlMap.SelfLink = f.umName()
 	f.Um = append(f.Um, urlMap)
-	return urlMap, nil
+	return nil
 }
 
 // UpdateUrlMap fakes updating url-maps.
-func (f *FakeLoadBalancers) UpdateUrlMap(urlMap *compute.UrlMap) (*compute.UrlMap, error) {
+func (f *FakeLoadBalancers) UpdateUrlMap(urlMap *compute.UrlMap) error {
 	f.calls = append(f.calls, "UpdateUrlMap")
 	for i := range f.Um {
 		if f.Um[i].Name == urlMap.Name {
 			f.Um[i] = urlMap
-			return urlMap, nil
+			return nil
 		}
 	}
-	return nil, nil
+	return fmt.Errorf("url map %v not found", urlMap.Name)
 }
 
 // DeleteUrlMap fakes url-map deletion.
@@ -231,15 +220,11 @@ func (f *FakeLoadBalancers) GetTargetHttpProxy(name string) (*compute.TargetHttp
 }
 
 // CreateTargetHttpProxy fakes creating a target http proxy.
-func (f *FakeLoadBalancers) CreateTargetHttpProxy(urlMap *compute.UrlMap, name string) (*compute.TargetHttpProxy, error) {
+func (f *FakeLoadBalancers) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error {
 	f.calls = append(f.calls, "CreateTargetHttpProxy")
-	proxy := &compute.TargetHttpProxy{
-		Name:     name,
-		UrlMap:   urlMap.SelfLink,
-		SelfLink: name,
-	}
+	proxy.SelfLink = proxy.Name
 	f.Tp = append(f.Tp, proxy)
-	return proxy, nil
+	return nil
 }
 
 // DeleteTargetHttpProxy fakes deleting a target http proxy.
@@ -280,16 +265,11 @@ func (f *FakeLoadBalancers) GetTargetHttpsProxy(name string) (*compute.TargetHtt
 }
 
 // CreateTargetHttpsProxy fakes creating a target http proxy.
-func (f *FakeLoadBalancers) CreateTargetHttpsProxy(urlMap *compute.UrlMap, cert *compute.SslCertificate, name string) (*compute.TargetHttpsProxy, error) {
+func (f *FakeLoadBalancers) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error {
 	f.calls = append(f.calls, "CreateTargetHttpsProxy")
-	proxy := &compute.TargetHttpsProxy{
-		Name:            name,
-		UrlMap:          urlMap.SelfLink,
-		SslCertificates: []string{cert.SelfLink},
-		SelfLink:        name,
-	}
+	proxy.SelfLink = proxy.Name
 	f.Tps = append(f.Tps, proxy)
-	return proxy, nil
+	return nil
 }
 
 // DeleteTargetHttpsProxy fakes deleting a target http proxy.

--- a/controllers/gce/loadbalancers/interfaces.go
+++ b/controllers/gce/loadbalancers/interfaces.go
@@ -28,25 +28,25 @@ import (
 type LoadBalancers interface {
 	// Forwarding Rules
 	GetGlobalForwardingRule(name string) (*compute.ForwardingRule, error)
-	CreateGlobalForwardingRule(proxyLink, ip, name, portRange string) (*compute.ForwardingRule, error)
+	CreateGlobalForwardingRule(rule *compute.ForwardingRule) error
 	DeleteGlobalForwardingRule(name string) error
 	SetProxyForGlobalForwardingRule(fw, proxy string) error
 
 	// UrlMaps
 	GetUrlMap(name string) (*compute.UrlMap, error)
-	CreateUrlMap(backend *compute.BackendService, name string) (*compute.UrlMap, error)
-	UpdateUrlMap(urlMap *compute.UrlMap) (*compute.UrlMap, error)
+	CreateUrlMap(urlMap *compute.UrlMap) error
+	UpdateUrlMap(urlMap *compute.UrlMap) error
 	DeleteUrlMap(name string) error
 
 	// TargetProxies
 	GetTargetHttpProxy(name string) (*compute.TargetHttpProxy, error)
-	CreateTargetHttpProxy(urlMap *compute.UrlMap, name string) (*compute.TargetHttpProxy, error)
+	CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error
 	DeleteTargetHttpProxy(name string) error
 	SetUrlMapForTargetHttpProxy(proxy *compute.TargetHttpProxy, urlMap *compute.UrlMap) error
 
 	// TargetHttpsProxies
 	GetTargetHttpsProxy(name string) (*compute.TargetHttpsProxy, error)
-	CreateTargetHttpsProxy(urlMap *compute.UrlMap, SSLCerts *compute.SslCertificate, name string) (*compute.TargetHttpsProxy, error)
+	CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error
 	DeleteTargetHttpsProxy(name string) error
 	SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, urlMap *compute.UrlMap) error
 	SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, SSLCerts *compute.SslCertificate) error


### PR DESCRIPTION
**Do not merge**

These changes are in response to https://github.com/kubernetes/kubernetes/pull/48989. When the ingress repo's vendored version of kubernetes core is updated again, the changes in this PR can be used.