### PR TITLE
Return reference to object providing Endpoint

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -1188,6 +1188,7 @@ func (ic *GenericController) getEndpoints(
 					Port:        fmt.Sprintf("%v", targetPort),
 					MaxFails:    hz.MaxFails,
 					FailTimeout: hz.FailTimeout,
+					Target:      epAddress.TargetRef,
 				}
 				upsServers = append(upsServers, ups)
 				adus[ep] = true

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -193,6 +193,8 @@ type Endpoint struct {
 	// of unsuccessful attempts to communicate with the server should happen
 	// to consider the endpoint unavailable
 	FailTimeout int `json:"failTimeout"`
+	// Target returns a reference to the object providing the endpoint
+	Target *api.ObjectReference `json:"target"`
 }
 
 // Server describes a website

--- a/core/pkg/ingress/types_equals.go
+++ b/core/pkg/ingress/types_equals.go
@@ -258,6 +258,9 @@ func (e1 *Endpoint) Equal(e2 *Endpoint) bool {
 	if e1.FailTimeout != e2.FailTimeout {
 		return false
 	}
+	if e1.Target != e2.Target {
+		return false
+	}
 
 	return true
 }


### PR DESCRIPTION
#### Summary

This adds a new field `Target` to the `ingress.Endpoint` type, which references the object providing that Endpoint.

#### Use case

I am writing a controller for Apache 2 and want to provide the ability to enable stickiness in front of Tomcat backends. The standard way to achieve this is to set the `route=` parameter for every *BalancerMember* (equivalent of *upstream.server* in nginx). This parameter must match the value of `jvmRoute=` on the backend.

Without a reference to the Pod providing the endpoint I can't reliably set a route Apache 2 and Tomcat can agree on, like the Pod's name.

ref: https://httpd.apache.org/docs/2.4/mod/mod_proxy_balancer.html#stickyness_implementation