### PR TITLE
Fix config name in the example.

### DIFF
--- a/examples/customization/custom-headers/nginx/custom-headers.yaml
+++ b/examples/customization/custom-headers/nginx/custom-headers.yaml
@@ -5,5 +5,5 @@ data:
   X-Using-Nginx-Controller: "true"
 kind: ConfigMap
 metadata:
-  name: proxy-headers
+  name: custom-headers
   namespace: kube-system


### PR DESCRIPTION
Replace `proxy-headers` with `custom-headers` to match [nginx-load-balancer-conf.yaml](https://github.com/kubernetes/ingress/blob/master/examples/customization/custom-headers/nginx/nginx-load-balancer-conf.yaml#L3)