### PR TITLE
Allow TEMP_DIR to be set externally

### DIFF
--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -54,7 +54,7 @@ endif
 #        QEMUARCH=s390x
 #endif
 
-TEMP_DIR := $(shell mktemp -d)
+TEMP_DIR ?= $(shell mktemp -d)
 
 all: all-container
 


### PR DESCRIPTION
This makes it easier to plug the repo into other build systems.

Ex:
i'm using different build stages, and want to keep using `make controllers`, but have my own specific requirements for building the docker image itself. This way i can pick up the Go binary from a predictable temp dir.