### PR TITLE
[GLBC] Bump GLBC version to 0.9.6

### DIFF
--- a/controllers/gce/Makefile
+++ b/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.9.5
+TAG = 0.9.6
 PREFIX = gcr.io/google_containers/glbc
 
 server:

--- a/controllers/gce/README.md
+++ b/controllers/gce/README.md
@@ -327,7 +327,7 @@ So simply delete the replication controller:
 $ kubectl get rc glbc
 CONTROLLER   CONTAINER(S)           IMAGE(S)                                      SELECTOR                    REPLICAS   AGE
 glbc         default-http-backend   gcr.io/google_containers/defaultbackend:1.0   k8s-app=glbc,version=v0.5   1          2m
-             l7-lb-controller       gcr.io/google_containers/glbc:0.9.5
+             l7-lb-controller       gcr.io/google_containers/glbc:0.9.6
 
 $ kubectl delete rc glbc
 replicationcontroller "glbc" deleted

--- a/controllers/gce/main.go
+++ b/controllers/gce/main.go
@@ -68,7 +68,7 @@ const (
 	alphaNumericChar = "0"
 
 	// Current docker image version. Only used in debug logging.
-	imageVersion = "glbc:0.9.5"
+	imageVersion = "glbc:0.9.6"
 
 	// Key used to persist UIDs to configmaps.
 	uidConfigMapName = "ingress-uid"

--- a/controllers/gce/rc.yaml
+++ b/controllers/gce/rc.yaml
@@ -24,18 +24,18 @@ metadata:
   name: l7-lb-controller
   labels:
     k8s-app: glbc
-    version: v0.9.5
+    version: v0.9.6
 spec:
   # There should never be more than 1 controller alive simultaneously.
   replicas: 1
   selector:
     k8s-app: glbc
-    version: v0.9.5
+    version: v0.9.6
   template:
     metadata:
       labels:
         k8s-app: glbc
-        version: v0.9.5
+        version: v0.9.6
         name: glbc
     spec:
       terminationGracePeriodSeconds: 600
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.9.5
+      - image: gcr.io/google_containers/glbc:0.9.6
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**Major Changes**
 - https://github.com/kubernetes/ingress/pull/994 Bug fix: Re-vendor latest GCE cloudprovider package
   - Allows unknown values in gce.conf
 - https://github.com/kubernetes/ingress/pull/1063 Bug fix: Ignore error when deleting instance groups that are used by ILBs
 - https://github.com/kubernetes/ingress/pull/1023 Bug fix: Retry creation of cloudprovider client with configuration
 - https://github.com/kubernetes/ingress/pull/393: Set health check HTTP Host header via readiness probe header


Closes #1059