### PR TITLE
(feat/ #374) support proxy timeout

### DIFF
--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -319,6 +319,11 @@ type Configuration struct {
 	// Sets the maximum size of the variables hash table.
 	// http://nginx.org/en/docs/http/ngx_http_map_module.html#variables_hash_max_size
 	LimitConnZoneVariable string `json:"limit-conn-zone-variable,omitempty"`
+
+	// Sets the timeout between two successive read or write operations on client or proxied server connections.
+	// If no data is transmitted within this time, the connection is closed.
+	// http://nginx.org/en/docs/stream/ngx_stream_proxy_module.html#proxy_timeout
+	ProxyStreamTimeout string `json:"proxy-stream-timeout,omitempty"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -368,6 +373,7 @@ func NewDefault() Configuration {
 		VariablesHashBucketSize:    64,
 		VariablesHashMaxSize:       2048,
 		UseHTTP2:                   true,
+		ProxyStreamTimeout:         "600s",
 		Backend: defaults.Backend{
 			ProxyBodySize:        bodySize,
 			ProxyConnectTimeout:  5,

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -584,6 +584,7 @@ stream {
     server {
         listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};
         {{ if $IsIPV6Enabled }}listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};{{ end }}
+        proxy_timeout                  {{ $cfg.ProxyStreamTimeout }};
         proxy_pass              tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
     }
 
@@ -601,6 +602,7 @@ stream {
         listen                  {{ $udpServer.Port }} udp;
         {{ if $IsIPV6Enabled }}listen                  [::]:{{ $udpServer.Port }} udp;{{ end }}
         proxy_responses         1;
+        proxy_timeout                  {{ $cfg.ProxyStreamTimeout }};
         proxy_pass              udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }};
     }
     {{ end }}

--- a/controllers/nginx/test/data/config.json
+++ b/controllers/nginx/test/data/config.json
@@ -38,6 +38,7 @@
 		"sslSessionTimeout": "10m",
 		"useGzip": true,
 		"useHttp2": true,
+		"proxyStreamTimeout": "600s",
 		"vtsStatusZoneSize": "10m",
 		"workerProcesses": 1,
 		"limitConnZoneVariable": "$the_real_ip"


### PR DESCRIPTION
#374
add ingress.kubernetes.io/proxyTimeout annotation in L4-configmap. default alse 600s.
```
apiVersion: v1
data:
  "99": caicloud-io/serving-manager:8080
kind: ConfigMap
metadata:
  annotations:
    ingress.kubernetes.io/proxyTimeout: 1h
  name: proxy-nginx-tcp
  namespace: kube-system
```