### PR TITLE
Fix ConfigMap's namespace in custom configuration example for nginx

### DIFF
--- a/examples/customization/custom-configuration/nginx/nginx-load-balancer-conf.yaml
+++ b/examples/customization/custom-configuration/nginx/nginx-load-balancer-conf.yaml
@@ -1,8 +1,11 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-custom-configuration
+  labels:
+    k8s-app: nginx-ingress-controller
+  namespace: kube-system
 data:
   proxy-connect-timeout: "10"
   proxy-read-timeout: "120"
   proxy-send-timeout: "120"
-kind: ConfigMap
-metadata:
-  name: nginx-custom-configuration


### PR DESCRIPTION
The configmap option `--configmap=$(POD_NAMESPACE)/nginx-custom-configuration` in the `nginx-custom-configuration.yaml` deployment expects the ConfigMap to be in the `kube-system` namespace but it was not set in the ConfigMap definition.