### PR TITLE
Add flag always-enable-tls to enable TLS even if no tls section is defined for the ingress

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -50,6 +50,8 @@ Usage of :
       --configmap string                 Name of the ConfigMap that contains the custom configuration use
       --default-backend-service string   Service used to serve a 404 page for the default backend. Takes the form namespace/name. The controller uses the first node port of this Service for the default backend.
       --default-ssl-certificate string   Name of the secret that contains a SSL certificate to be used as default for a HTTPS catch-all server
+      --always-enable-tls bool           Enable tls using the default-ssl-certificate even if no tls section is defined
+		for the ingress.
       --election-id string               Election id to use for status update. (default "ingress-controller-leader")
       --force-namespace-isolation        Force namespace isolation. This flag is required to avoid the reference of secrets or configmaps located in a different namespace than the specified in the flag --watch-namespace.
       --health-check-path string         Defines the URL to be used as health check inside in the default server in NGINX. (default "/healthz")
@@ -68,7 +70,7 @@ Usage of :
 		  The ports 80 and 443 are not allowed as external ports. This ports are reserved for the backend
       --udp-services-configmap string    Name of the ConfigMap that contains the definition of the UDP services to expose.
 		  The key in the map indicates the external port to be used. The value is the name of the service with the format namespace/serviceName and the port of the service could be a number of the name of the port.
-      --update-status                    Indicates if the ingress controller should update the Ingress status IP/hostname. Default is true (default true)
+      --update-status bool               Indicates if the ingress controller should update the Ingress status IP/hostname. Default is true (default true)
 -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
       --watch-namespace string           Namespace to watch for Ingress. Default is to watch all namespaces

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -342,7 +342,7 @@ func (ic GenericController) GetDefaultBackend() defaults.Backend {
 }
 
 // GetRecorder returns the event recorder
-func (ic GenericController) GetRecoder() record.EventRecorder {
+func (ic GenericController) GetRecorder() record.EventRecorder {
 	return ic.recorder
 }
 

--- a/core/pkg/ingress/controller/controller_test.go
+++ b/core/pkg/ingress/controller/controller_test.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"testing"
+
+	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/ingress/core/pkg/ingress"
+)
+
+func buildGenericControllerForCertTest() *GenericController {
+	return &GenericController{
+		cfg: &Configuration{},
+	}
+}
+
+func buildTestIngressRuleForCertTest() extensions.Ingress {
+	return extensions.Ingress{
+		Spec: extensions.IngressSpec{
+			Rules: []extensions.IngressRule{
+				extensions.IngressRule{
+					Host: "hostWithTLS",
+				},
+				extensions.IngressRule{
+					Host: "hostWithoutTLS",
+				},
+			},
+			TLS: []extensions.IngressTLS{
+				extensions.IngressTLS{
+					Hosts: []string{"hostWithTLS"},
+				},
+			},
+		},
+	}
+}
+
+func buildTestServersForCertTest() map[string]*ingress.Server {
+	return map[string]*ingress.Server{
+		"hostWithTLS": &ingress.Server{
+			Hostname: "hostWithTLS",
+		},
+		"hostWithoutTLS": &ingress.Server{
+			Hostname: "hostWithoutTLS",
+		},
+	}
+}
+
+func TestConfigureTLSforIng(t *testing.T) {
+	ic := buildGenericControllerForCertTest()
+
+	testIng := buildTestIngressRuleForCertTest()
+	testServers := buildTestServersForCertTest()
+
+	defaultPemFileName := "defaultPemFileName"
+	defaultPemSHA := "defaultPemSHA"
+
+	ic.configureTLSforIng(&testIng, testServers, defaultPemFileName, defaultPemSHA)
+	if testServers["hostWithTLS"].SSLCertificate != defaultPemFileName {
+		t.Errorf("SSLCertificate set to %s instead of %s", testServers["hostWithTLS"].SSLCertificate, defaultPemFileName)
+	}
+	if testServers["hostWithoutTLS"].SSLCertificate != "" {
+		t.Errorf("SSLCertificate set to %s instead of being empty", testServers["hostWithoutTLS"].SSLCertificate)
+	}
+
+	ic.cfg.AlwaysEnableTLS = true
+	ic.configureTLSforIng(&testIng, testServers, defaultPemFileName, defaultPemSHA)
+	if testServers["hostWithTLS"].SSLCertificate != defaultPemFileName {
+		t.Errorf("SSLCertificate set to %s instead of %s", testServers["hostWithTLS"].SSLCertificate, defaultPemFileName)
+	}
+	if testServers["hostWithoutTLS"].SSLCertificate != defaultPemFileName {
+		t.Errorf("SSLCertificate set to %s instead of %s", testServers["hostWithoutTLS"].SSLCertificate, defaultPemFileName)
+	}
+}

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -78,6 +78,9 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		defSSLCertificate = flags.String("default-ssl-certificate", "", `Name of the secret 
 		that contains a SSL certificate to be used as default for a HTTPS catch-all server`)
 
+		defAlwaysEnableTLS = flags.Bool("always-enable-tls", false, `Enable tls using the default-ssl-certificate even if no tls section is defined
+		for the ingress.`)
+
 		defHealthzURL = flags.String("health-check-path", "/healthz", `Defines 
 		the URL to be used as health check inside in the default server in NGINX.`)
 
@@ -171,6 +174,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		TCPConfigMapName:        *tcpConfigMapName,
 		UDPConfigMapName:        *udpConfigMapName,
 		DefaultSSLCertificate:   *defSSLCertificate,
+		AlwaysEnableTLS:         *defAlwaysEnableTLS,
 		DefaultHealthzURL:       *defHealthzURL,
 		PublishService:          *publishSvc,
 		Backend:                 backend,


### PR DESCRIPTION
I added a new flag to the controller always-enable-tls, default false. With this flag set to true ingress rules will use the default cert even if the ingress doesn't contain a TLS section.
I moved the TLS setup code for the servers to a separate function so it's easier to test.

I want this so we at our company don't have to specify the TLS section in every ingress and don't risk that someone forgets to set it and disables TLS by accident. We use a wildcard certificate as default cert in our ingress.

I will add doc for the new flag as well. -> Done
I haven't manually tested it yet. -> Done, works.