### PR TITLE
Specify type for default backend service

### DIFF
--- a/examples/deployment/nginx/default-backend.yaml
+++ b/examples/deployment/nginx/default-backend.yaml
@@ -44,6 +44,7 @@ metadata:
   labels:
     k8s-app: default-http-backend
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8080


### PR DESCRIPTION
Without an explicit `type: NodePort` on the default backend service, I got an error when trying to apply it:

    The Service "default-http-backend" is invalid: spec.ports[0].nodePort: Invalid value: 31950: may not be used when `type` is 'ClusterIP'