### PR TITLE
sync the secret if the certificate isn't present

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -1110,8 +1110,12 @@ func (ic *GenericController) createServers(data []interface{},
 			key := fmt.Sprintf("%v/%v", ing.Namespace, tlsSecretName)
 			bc, exists := ic.sslCertTracker.Get(key)
 			if !exists {
-				glog.Infof("ssl certificate \"%v\" does not exist in local store", key)
-				continue
+				ic.syncSecret(key)
+				bc, exists = ic.sslCertTracker.Get(key)
+				if !exists {
+					glog.Infof("ssl certificate \"%v\" does not exist in local store", key)
+					continue
+				}
 			}
 
 			cert := bc.(*ingress.SSLCert)


### PR DESCRIPTION
## Problem
When the controller is being started, there's a period where various ingress resources will have their TLS certificate not present.  This is shown by showing the "default certificate", for awhile until the controller syncs that secret.

If you have many ingresses ( think like >200 ), it can take minutes for the entire thing to converge.  You can see the error message in the logs:
```"ssl certificate \"some-cert\" does not exist in local store"```

## Reproduce
0. nginx ingress controller with 1 replica
1. create many ingresses and many updates, the idea is to get the the syncQueue as full as possible.
2. Wait for steady state
3. do ```while true ; do curl https://someplace.with.valid.cer.com/ -m 1s ; done```
4. delete the ingress controller
5. observe many invalid cert errors

## Fix
Since the queue is rate limited, and the only time that certificate syncing is done when the specific ingress of the event is processed.  This leaves a big window of invalid certs as NGINX needs to know the entire state of the system (and indeed it makes sites for them, just no certificates).

When the cert isn't found, I added a syncSecret call so that they can be loaded.  The result is how I would expect now, instead of invalid cert errors we get timeouts until the site is loaded.  This is much more preferable than serving the invalid cert.  And it also converges in about 20s instead of minutes.

## Other ways to fix
I believe this is this way because for the GCE controller, one ingress == one load balancer, but NGINX is many ingress -> one load balancer instance.

1. We could sync all the certificates on start.
