### PR TITLE
Use unmodified `PeriodSeconds` setting

### DIFF
--- a/controllers/gce/backends/backends.go
+++ b/controllers/gce/backends/backends.go
@@ -472,6 +472,6 @@ func applyProbeSettingsToHC(p *v1.Probe, hc *healthchecks.HealthCheck) {
 	hc.RequestPath = healthPath
 	hc.Host = host
 	hc.Description = "Kubernetes L7 health check generated with readiness probe settings."
-	hc.CheckIntervalSec = int64(p.PeriodSeconds) + int64(healthchecks.DefaultHealthCheckInterval.Seconds())
+	hc.CheckIntervalSec = int64(p.PeriodSeconds)
 	hc.TimeoutSec = int64(p.TimeoutSeconds)
 }


### PR DESCRIPTION
Use actual interval setting from readiness probe instead of modifying.

Fix #1213 