### PR TITLE
Trivial fixes in core/pkg/net

### DIFF
--- a/core/pkg/net/dns/dns.go
+++ b/core/pkg/net/dns/dns.go
@@ -38,7 +38,7 @@ func GetSystemNameServers() ([]net.IP, error) {
 	lines := strings.Split(string(file), "\n")
 	for l := range lines {
 		trimmed := strings.TrimSpace(lines[l])
-		if strings.HasPrefix(trimmed, "#") {
+		if len(trimmed) == 0 || trimmed[0] == '#' || trimmed[0] == ';' {
 			continue
 		}
 		fields := strings.Fields(trimmed)

--- a/core/pkg/net/dns/dns_test.go
+++ b/core/pkg/net/dns/dns_test.go
@@ -40,6 +40,8 @@ func TestGetDNSServers(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	ioutil.WriteFile(file.Name(), []byte(`
+	# comment
+	; comment
 	nameserver 2001:4860:4860::8844
 	nameserver 2001:4860:4860::8888
 	nameserver 8.8.8.8

--- a/core/pkg/net/net.go
+++ b/core/pkg/net/net.go
@@ -16,15 +16,9 @@ limitations under the License.
 
 package net
 
-import (
-	_net "net"
-	"strings"
-)
+import _net "net"
 
 // IsIPV6 checks if the input contains a valid IPV6 address
 func IsIPV6(ip _net.IP) bool {
-	if dp := strings.Index(ip.String(), ":"); dp != -1 {
-		return true
-	}
-	return false
+	return ip.To4() == nil
 }


### PR DESCRIPTION
Naive PR. 

- I feel string comparison is hacky to judge an IP is IPv6 or not. Simplify util method IsIPV6.
- Fixes parsing of /etc/resolv.conf