### PR TITLE
Correct nginx tmpl

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -134,6 +134,7 @@ http {
         ''               close;
     }
 
+    {{ if $cfg.UseProxyProtocol }}
     # trust http_x_forwarded_proto headers correctly indicate ssl offloading
     map $http_x_forwarded_proto $pass_access_scheme {
         default          $http_x_forwarded_proto;
@@ -145,16 +146,24 @@ http {
        ''                $server_port;
     }
 
-    {{ if $cfg.UseProxyProtocol }}
     map $http_x_forwarded_for $the_real_ip {
         default          $http_x_forwarded_for;
         ''               $proxy_protocol_addr;
     }
     {{ else }}
-    map $http_x_forwarded_for $the_real_ip {
-        default          $http_x_forwarded_for;
-        ''               $realip_remote_addr;
+
+    map $http_x_forwarded_proto $pass_access_scheme {
+        default          $scheme;
     }
+
+    map $http_x_forwarded_port $pass_server_port {
+       default           $server_port;
+    }
+
+    map $http_x_forwarded_for $the_real_ip {
+        default          $remote_addr;
+    }
+
     {{ end }}
 
     {{ if $all.IsSSLPassthroughEnabled }}
@@ -259,7 +268,7 @@ http {
     {{ end }}
 
     upstream {{ $upstream.Name }} {
-        # Load balance algorithm; empty for round robin, which is the default
+        {{/* Load balance algorithm; empty for round robin, which is the default */}}
         {{ if ne $cfg.LoadBalanceAlgorithm "round_robin" }}
         {{ $cfg.LoadBalanceAlgorithm }};
         {{ end }}

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -28,13 +28,11 @@ http {
     {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
     {{ if $cfg.UseProxyProtocol }}
     real_ip_header      proxy_protocol;
-    {{ else }}
-    real_ip_header      X-Forwarded-For;
-    {{ end }}
 
     real_ip_recursive   on;
     {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
     set_real_ip_from    {{ $trusted_ip }};
+    {{ end }}
     {{ end }}
 
     {{/* databases used to determine the country depending on the client IP address */}}


### PR DESCRIPTION
This is an improvement to NGINX template security, with the following logic:

* Is the 'UseProxyProtocol' true? Then accept headers sent by Proxy to NGINX, real_ip_header and others
* Is the 'UseProxyProtocol' false (default)? Then use the default variables as real_ip_header

Additionally, I've made a correction in template in line [262](https://github.com/kubernetes/ingress/compare/master...estaleiro:correct-nginx-tmpl?expand=1#diff-b7803798d356c6c17a90d93cc58bdbaaL262) putting this comment as inside template comment, instead of a repeat comment for each upstream.

This solves #1000 

