### PR TITLE
Remove useless variable in nginx.tmpl

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -328,7 +328,6 @@ http {
     }
     {{ end }}
 
-    {{ $backlogSize := .BacklogSize }}
     {{ range $index, $server := $servers }}
     server {
         server_name {{ $server.Hostname }};


### PR DESCRIPTION
Remove useless variable `backlogSize` in nginx.tmpl