### PR TITLE
Add Validation for Client Body Buffer Size

### DIFF
--- a/controllers/nginx/pkg/template/template_test.go
+++ b/controllers/nginx/pkg/template/template_test.go
@@ -232,3 +232,42 @@ func TestBuildDenyVariable(t *testing.T) {
 		t.Errorf("Expected '%v' but returned '%v'", a, b)
 	}
 }
+
+func TestBuildClientBodyBufferSize(t *testing.T) {
+	a := isValidClientBodyBufferSize("1000")
+	if a != true {
+		t.Errorf("Expected '%v' but returned '%v'", true, a)
+	}
+	b := isValidClientBodyBufferSize("1000k")
+	if b != true {
+		t.Errorf("Expected '%v' but returned '%v'", true, b)
+	}
+	c := isValidClientBodyBufferSize("1000m")
+	if c != true {
+		t.Errorf("Expected '%v' but returned '%v'", true, c)
+	}
+	d := isValidClientBodyBufferSize("1000km")
+	if d != false {
+		t.Errorf("Expected '%v' but returned '%v'", false, d)
+	}
+	e := isValidClientBodyBufferSize("1000mk")
+	if e != false {
+		t.Errorf("Expected '%v' but returned '%v'", false, e)
+	}
+	f := isValidClientBodyBufferSize("1000kk")
+	if f != false {
+		t.Errorf("Expected '%v' but returned '%v'", false, f)
+	}
+	g := isValidClientBodyBufferSize("1000mm")
+	if g != false {
+		t.Errorf("Expected '%v' but returned '%v'", false, g)
+	}
+	h := isValidClientBodyBufferSize(nil)
+	if h != false {
+		t.Errorf("Expected '%v' but returned '%v'", false, h)
+	}
+	i := isValidClientBodyBufferSize("")
+	if i != false {
+		t.Errorf("Expected '%v' but returned '%v'", false, i)
+	}
+}

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -571,7 +571,7 @@ stream {
         proxy_ssl_server_name       on;
 
         client_max_body_size        "{{ $location.Proxy.BodySize }}";
-        {{ if $location.ClientBodyBufferSize }}
+        {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
         client_body_buffer_size     {{ $location.ClientBodyBufferSize }};
         {{ end }}
 
@@ -640,7 +640,7 @@ stream {
         {{ end }}
 
         client_max_body_size                    "{{ $location.Proxy.BodySize }}";
-        {{ if $location.ClientBodyBufferSize }}
+        {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
         client_body_buffer_size                 {{ $location.ClientBodyBufferSize }};
         {{ end }}
 


### PR DESCRIPTION
Adds validation so that if a bad value is input into the client body buffer size annotation then client_body_buffer_size is not set. That way a log error is thrown and it fails gracefully rather than killing the ingress controller.