### PR TITLE
Add support for access-log-path and error-log-path

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -311,6 +311,10 @@ Example usage: `custom-http-errors: 404,415`
 
 **disable-access-log:** Disables the Access Log from the entire Ingress Controller. This is 'false' by default.
 
+**access-log-path:** Access log path. Goes to '/var/log/nginx/access.log' by default. http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
+
+**error-log-path:** Error log path. Goes to '/var/log/nginx/error.log' by default. http://nginx.org/en/docs/ngx_core_module.html#error_log
+
 **disable-ipv6:** Disable listening on IPV6. This is 'false' by default.
 
 **enable-dynamic-tls-records:** Enables dynamically sized TLS records to improve time-to-first-byte. Enabled by default. See [CloudFlare's blog](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency) for more information.

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -92,6 +92,16 @@ type Configuration struct {
 	// By default this is disabled
 	AllowBackendServerHeader bool `json:"allow-backend-server-header"`
 
+	// AccessLogPath sets the path of the access logs if enabled
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
+	// By default access logs go to /var/log/nginx/access.log
+	AccessLogPath string `json:"access-log-path,omitempty"`
+
+	// ErrorLogPath sets the path of the error logs
+	// http://nginx.org/en/docs/ngx_core_module.html#error_log
+	// By default error logs go to /var/log/nginx/error.log
+	ErrorLogPath string `json:"error-log-path,omitempty"`
+
 	// EnableDynamicTLSRecords enables dynamic TLS record sizes
 	// https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency
 	// By default this is enabled
@@ -340,6 +350,8 @@ func NewDefault() Configuration {
 	defIPCIDR = append(defIPCIDR, "0.0.0.0/0")
 	cfg := Configuration{
 		AllowBackendServerHeader:   false,
+		AccessLogPath:              "/var/log/nginx/access.log",
+		ErrorLogPath:               "/var/log/nginx/error.log",
 		ClientHeaderBufferSize:     "1k",
 		ClientHeaderTimeout:        60,
 		ClientBodyBufferSize:       "8k",

--- a/controllers/nginx/pkg/template/configmap_test.go
+++ b/controllers/nginx/pkg/template/configmap_test.go
@@ -39,6 +39,8 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"skip-access-log-urls":       "/log,/demo,/test",
 		"use-proxy-protocol":         "true",
 		"disable-access-log":         "true",
+		"access-log-path":            "/var/log/test/access.log",
+		"error-log-path":             "/var/log/test/error.log",
 		"use-gzip":                   "true",
 		"enable-dynamic-tls-records": "false",
 		"gzip-types":                 "text/html",
@@ -47,6 +49,8 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def := config.NewDefault()
 	def.CustomHTTPErrors = []int{300, 400}
 	def.DisableAccessLog = true
+	def.AccessLogPath = "/var/log/test/access.log"
+	def.ErrorLogPath = "/var/log/test/error.log"
 	def.SkipAccessLogURLs = []string{"/log", "/demo", "/test"}
 	def.ProxyReadTimeout = 1
 	def.ProxySendTimeout = 2

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -118,9 +118,9 @@ http {
     {{ if $cfg.DisableAccessLog }}
     access_log off;
     {{ else }}
-    access_log /var/log/nginx/access.log upstreaminfo if=$loggable;
+    access_log {{ $cfg.AccessLogPath }} upstreaminfo if=$loggable;
     {{ end }}
-    error_log  /var/log/nginx/error.log {{ $cfg.ErrorLogLevel }};
+    error_log  {{ $cfg.ErrorLogPath }} {{ $cfg.ErrorLogLevel }};
 
     {{ buildResolvers $cfg.Resolver }}
 
@@ -417,10 +417,10 @@ stream {
     {{ if $cfg.DisableAccessLog }}
     access_log off;
     {{ else }}
-    access_log /var/log/nginx/access.log log_stream;
+    access_log {{ $cfg.AccessLogPath }} log_stream;
     {{ end }}
 
-    error_log  /var/log/nginx/error.log;
+    error_log  {{ $cfg.ErrorLogPath }};
 
     # TCP services
     {{ range $i, $tcpServer := .TCPBackends }}


### PR DESCRIPTION
By default, the access logs of the Nginx Ingress go to `/var/log/nginx/access.log` which is a synlink to `/dev/stdout`. We are using a syslog server to store all our access logs which leaves us with two options:
* parsing the access logs out of the container stdout
* modifying the template to specify a different destination (our syslog server)

For performance reason and simplicity we choose to directly send our logs from Nginx to a syslog service. This is working fine by modifying the template. 

However, since it might interest other people to have the log destination customizable, a cleaner solution would be to make it  configurable in the ConfigMap and that's what this PR is about.

This pull-requests adds support for a `access-log-path` field in the Nginx ConfigMap to set a different path than the default one (`/var/log/nginx/access.log`). The value is put as is in the Nginx template, therefore also allowing to configure a syslog server as log destination.
 