### PR TITLE
Graceful shutdown for Nginx

### DIFF
--- a/controllers/nginx/pkg/cmd/controller/main.go
+++ b/controllers/nginx/pkg/cmd/controller/main.go
@@ -23,17 +23,15 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"k8s.io/ingress/core/pkg/ingress/controller"
 )
 
 func main() {
 	// start a new nginx controller
 	ngx := newNGINXController()
-	// create a custom Ingress controller using NGINX as backend
-	ic := controller.NewIngressController(ngx)
-	go handleSigterm(ic)
+
+	go handleSigterm(ngx)
 	// start the controller
-	ic.Start()
+	ngx.Start()
 	// wait
 	glog.Infof("shutting down Ingress controller...")
 	for {
@@ -42,14 +40,14 @@ func main() {
 	}
 }
 
-func handleSigterm(ic *controller.GenericController) {
+func handleSigterm(ngx *NGINXController) {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
 	<-signalChan
 	glog.Infof("Received SIGTERM, shutting down")
 
 	exitCode := 0
-	if err := ic.Stop(); err != nil {
+	if err := ngx.Stop(); err != nil {
 		glog.Infof("Error during shutdown %v", err)
 		exitCode = 1
 	}


### PR DESCRIPTION
## Issue
Nginx is not being gracefully shut down when a Nginx Ingress Controller container is stopped, leading to broken connections. It looks like the `SIGTERM` sent to the controller to stop it is simply forwarded to the Nginx server. 

The problem is that `SIGTERM` means "Exit as quick as you can" for Nginx ([Nginx doc](http://nginx.org/en/docs/control.html). For a graceful shutdown we should rather send a `SIGQUIT`.

A solution to this issue is to prevent the Nginx Ingress Controller to forward all the signals it gets to Nginx, allowing us to control what's sent to the Nginx process. When shutting down, the controller would then send a `SIGQUIT` to Nginx. Nginx itself will wait 10secondes (`worker_shutdown_timeout`) for the worker to shutdown.

## Testing
You need a backend exposed on the Ingress that responds slowly. I used one with a 10 secondes response time. Trigger an Ingress deployment and call this slow URL. If your slow URL get an answer before the Nginx is tear down, re-execute it.

We expected this request to be answered to. You should see in the Ingress logs that it's not immediately exiting but waiting for the request to finish. 
Additionally, you can `strace` the Nginx master process to make sure `SIGQUIT` is not being sent instead of `SIGTERM`.
