### PR TITLE
Add support for 'worker-shutdown-timeout'

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -187,7 +187,7 @@ the whole body or only its part is written to a temporary file. By default, buff
 This is 8K on x86, other 32-bit platforms, and x86-64. It is usually 16K on other 64-bit platforms. This annotation is
 applied to each location provided in the ingress rule.
 
-*Note:* The annotation value must be given in a valid format otherwise the 
+*Note:* The annotation value must be given in a valid format otherwise the
 For example to set the client-body-buffer-size the following can be done:
 * `ingress.kubernetes.io/client-body-buffer-size: "1000"` # 1000 bytes
 * `ingress.kubernetes.io/client-body-buffer-size: 1k` # 1 kilobyte
@@ -466,6 +466,8 @@ The default mime type list to compress is: `application/atom+xml application/jav
 **whitelist-source-range:** Sets the default whitelisted IPs for each `server` block. This can be overwritten by an annotation on an Ingress rule. See [ngx_http_access_module](http://nginx.org/en/docs/http/ngx_http_access_module.html).
 
 **worker-processes:** Sets the number of [worker processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes). The default of "auto" means number of available CPU cores.
+
+**worker-shutdown-timeout:** Sets a timeout for Nginx to [wait for worker to gracefully shutdown](http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout). The default is "10s".
 
 **limit-conn-zone-variable:** Sets parameters for a shared memory zone that will keep states for various keys of [limit_conn_zone](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone). The default of "$binary_remote_addr" variable’s size is always 4 bytes for IPv4 addresses or 16 bytes for IPv6 addresses.
 

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -315,6 +315,10 @@ type Configuration struct {
 	// http://nginx.org/en/docs/ngx_core_module.html#worker_processes
 	WorkerProcesses string `json:"worker-processes,omitempty"`
 
+	// Defines a timeout for a graceful shutdown of worker processes
+	// http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout
+	WorkerShutdownTimeout string `json:"worker-shutdown-timeout,omitempty"`
+
 	// Defines the load balancing algorithm to use. The deault is round-robin
 	LoadBalanceAlgorithm string `json:"load-balance,omitempty"`
 
@@ -397,6 +401,7 @@ func NewDefault() Configuration {
 		SSLSessionTimeout:          sslSessionTimeout,
 		UseGzip:                    true,
 		WorkerProcesses:            strconv.Itoa(runtime.NumCPU()),
+		WorkerShutdownTimeout:      "10s",
 		LoadBalanceAlgorithm:       defaultLoadBalancerAlgorithm,
 		VtsStatusZoneSize:          "10m",
 		VariablesHashBucketSize:    64,

--- a/controllers/nginx/pkg/template/configmap_test.go
+++ b/controllers/nginx/pkg/template/configmap_test.go
@@ -46,6 +46,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"gzip-types":                 "text/html",
 		"proxy-real-ip-cidr":         "1.1.1.1/8,2.2.2.2/24",
 		"bind-address":               "1.1.1.1,2.2.2.2,3.3.3,2001:db8:a0b:12f0::1,3731:54:65fe:2::a7,33:33:33::33::33",
+		"worker-shutdown-timeout":    "99s",
 	}
 	def := config.NewDefault()
 	def.CustomHTTPErrors = []int{300, 400}
@@ -61,6 +62,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.ProxyRealIPCIDR = []string{"1.1.1.1/8", "2.2.2.2/24"}
 	def.BindAddressIpv4 = []string{"1.1.1.1", "2.2.2.2"}
 	def.BindAddressIpv6 = []string{"[2001:db8:a0b:12f0::1]", "[3731:54:65fe:2::a7]"}
+	def.WorkerShutdownTimeout = "99s"
 
 	to := ReadConfig(conf)
 	if diff := pretty.Compare(to, def); diff != "" {

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -16,7 +16,7 @@ worker_rlimit_nofile {{ .MaxOpenFiles }};
 
 {{/* http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout */}}
 {{/* avoid waiting too long during a reload */}}
-worker_shutdown_timeout 10s;
+worker_shutdown_timeout {{ $cfg.WorkerShutdownTimeout }} ;
 
 events {
     multi_accept        on;


### PR DESCRIPTION
When reloading the configuration or gracefully shutting down, Nginx waits [10secondes](https://github.com/kubernetes/ingress/blob/80ff5e6ce8fb369ce19d873a14158963be90e9f7/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl#L19) for the workers to exit. 

It would be great if we could configure this value through the `ConfigMap` as it implicitely determines how long we are waiting for open connections to close. 