### PR TITLE
add missing yamls in controllers/nginx

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -95,14 +95,14 @@ $ ./rootfs/nginx-ingress-controller --running-in-cluster=false --default-backend
 
 First create a default backend:
 ```
-$ kubectl create -f examples/deployment/nginx/default-backend.yaml
+$ kubectl create -f examples/default-backend.yaml
 $ kubectl expose rc default-http-backend --port=80 --target-port=8080 --name=default-http-backend
 ```
 
 Loadbalancers are created via a ReplicationController or Daemonset:
 
 ```
-$ kubectl create -f examples/default/rc-default.yaml
+$ kubectl create -f examples/rc-default.yaml
 ```
 
 ## HTTP

--- a/controllers/nginx/examples/default-backend.yaml
+++ b/controllers/nginx/examples/default-backend.yaml
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  labels:
+    k8s-app: default-http-backend
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  namespace: kube-system
+  labels:
+    k8s-app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    k8s-app: default-http-backend

--- a/controllers/nginx/examples/ingress.yaml
+++ b/controllers/nginx/examples/ingress.yaml
@@ -1,0 +1,26 @@
+# This is the Ingress resource that creates a HTTP Loadbalancer configured
+# according to the Ingress rules.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: echomap
+spec:
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /foo
+        backend:
+          serviceName: echoheaders-x
+          servicePort: 80
+  - host: bar.baz.com
+    http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: echoheaders-y
+          servicePort: 80
+      - path: /foo
+        backend:
+          serviceName: echoheaders-x
+          servicePort: 80


### PR DESCRIPTION
`examples/ingress.yaml` and `examples/default/rc-default.yaml` are missing. And I did not find the latter...

Add default-backend.yaml because it is used.