### PR TITLE
Delete useless statement

### DIFF
--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -301,7 +301,7 @@ func buildProxyPass(host string, b interface{}, loc interface{}) string {
 		return defProxyPass
 	}
 
-	if path != slash && !strings.HasSuffix(path, slash) {
+	if !strings.HasSuffix(path, slash) {
 		path = fmt.Sprintf("%s/", path)
 	}
 


### PR DESCRIPTION
`!strings.HasSuffix(path, slash)` is sufficient here.