### PR TITLE
Add proxy-pass-params annotation and Backend field

### DIFF
--- a/core/pkg/ingress/annotations/proxy/main.go
+++ b/core/pkg/ingress/annotations/proxy/main.go
@@ -32,6 +32,7 @@ const (
 	cookiePath   = "ingress.kubernetes.io/proxy-cookie-path"
 	cookieDomain = "ingress.kubernetes.io/proxy-cookie-domain"
 	nextUpstream = "ingress.kubernetes.io/proxy-next-upstream"
+	passParams   = "ingress.kubernetes.io/proxy-pass-params"
 )
 
 // Configuration returns the proxy timeout to use in the upstream server/s
@@ -44,6 +45,7 @@ type Configuration struct {
 	CookieDomain   string `json:"cookieDomain"`
 	CookiePath     string `json:"cookiePath"`
 	NextUpstream   string `json:"nextUpstream"`
+	PassParams     string `json:"passParams"`
 }
 
 // Equal tests for equality between two Configuration types
@@ -73,6 +75,12 @@ func (l1 *Configuration) Equal(l2 *Configuration) bool {
 		return false
 	}
 	if l1.CookiePath != l2.CookiePath {
+		return false
+	}
+	if l1.NextUpstream != l2.NextUpstream {
+		return false
+	}
+	if l1.PassParams != l2.PassParams {
 		return false
 	}
 
@@ -132,5 +140,10 @@ func (a proxy) Parse(ing *extensions.Ingress) (interface{}, error) {
 		nu = defBackend.ProxyNextUpstream
 	}
 
-	return &Configuration{bs, ct, st, rt, bufs, cd, cp, nu}, nil
+	pp, err := parser.GetStringAnnotation(passParams, ing)
+	if err != nil || pp == "" {
+		pp = defBackend.ProxyPassParams
+	}
+
+	return &Configuration{bs, ct, st, rt, bufs, cd, cp, nu, pp}, nil
 }

--- a/core/pkg/ingress/annotations/proxy/main_test.go
+++ b/core/pkg/ingress/annotations/proxy/main_test.go
@@ -74,6 +74,7 @@ func (m mockBackend) GetDefaultBackend() defaults.Backend {
 		ProxyBufferSize:     "10k",
 		ProxyBodySize:       "3k",
 		ProxyNextUpstream:   "error",
+		ProxyPassParams:     "nocanon keepalive=On",
 	}
 }
 
@@ -87,6 +88,7 @@ func TestProxy(t *testing.T) {
 	data[bufferSize] = "1k"
 	data[bodySize] = "2k"
 	data[nextUpstream] = "off"
+	data[passParams] = "smax=5 max=10"
 	ing.SetAnnotations(data)
 
 	i, err := NewParser(mockBackend{}).Parse(ing)
@@ -114,6 +116,9 @@ func TestProxy(t *testing.T) {
 	}
 	if p.NextUpstream != "off" {
 		t.Errorf("expected off as next-upstream but returned %v", p.NextUpstream)
+	}
+	if p.PassParams != "smax=5 max=10" {
+		t.Errorf("expected \"smax=5 max=10\" as pass-params but returned \"%v\"", p.PassParams)
 	}
 }
 
@@ -148,5 +153,8 @@ func TestProxyWithNoAnnotation(t *testing.T) {
 	}
 	if p.NextUpstream != "error" {
 		t.Errorf("expected error as next-upstream but returned %v", p.NextUpstream)
+	}
+	if p.PassParams != "nocanon keepalive=On" {
+		t.Errorf("expected \"nocanon keepalive=On\" as pass-params but returned \"%v\"", p.PassParams)
 	}
 }

--- a/core/pkg/ingress/defaults/main.go
+++ b/core/pkg/ingress/defaults/main.go
@@ -53,6 +53,9 @@ type Backend struct {
 	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
 	ProxyNextUpstream string `json:"proxy-next-upstream"`
 
+	// Parameters for proxy-pass directive (eg. Apache web server).
+	ProxyPassParams string `json:"proxy-pass-params"`
+
 	// Name server/s used to resolve names of upstream servers into IP addresses.
 	// The file /etc/resolv.conf is used as DNS resolution configuration.
 	Resolver []net.IP

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -63,6 +63,7 @@ Key:
 | `session-cookie-name` | When `affinity` is set to `cookie`, the name of the cookie to use. | | nginx
 | `session-cookie-hash` | When `affinity` is set to `cookie`, the hash algorithm used: `md5`, `sha`, `index`. | | nginx
 | `proxy-body-size` | Maximum request body size. | | nginx, haproxy
+| `proxy-pass-params` | Parameters for proxy-pass directives. | |
 | `follow-redirects` | Follow HTTP redirects in the response and deliver the redirect target to the client. | | trafficserver
 | `kubernetes.io/ingress.global-static-ip-name` | Name of the static global IP address in GCP to use when provisioning the HTTPS load balancer. | empty string | gce
 


### PR DESCRIPTION
Some backends like Apache httpd accept [parameters after proxy-pass directives](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass). This annotation and global setting provide a place to set these.