### PR TITLE
Allow PATCH in enable-cors

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -523,7 +523,7 @@ stream {
         # Om nom nom cookies
         #
         add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS';
+        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, PATCH, OPTIONS';
         #
         # Custom headers and headers various browsers *should* be OK with but aren't
         #
@@ -549,11 +549,14 @@ stream {
      if ($request_method = 'DELETE') {
         set $cors_method 1;
      }
+     if ($request_method = 'PATCH') {
+        set $cors_method 1;
+     }
 
      if ($cors_method = 1) {
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS';
+        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, PATCH, OPTIONS';
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
      }
 {{ end }}


### PR DESCRIPTION
While using `ingress.kubernetes.io/enable-cors` is awesome and super easy to get started with, PATCH was left out. Not sure if this was intentional or not, but would love to see it available. 

Thoughts? 