### PR TITLE
Adds support for error page in Client Certificate Authentication

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -47,6 +47,7 @@ The following annotations are supported:
 |[ingress.kubernetes.io/auth-url](#external-authentication)|string|
 |[ingress.kubernetes.io/auth-tls-secret](#certificate-authentication)|string|
 |[ingress.kubernetes.io/auth-tls-verify-depth](#certificate-authentication)|number|
+|[ingress.kubernetes.io/auth-tls-error-page](#certificate-authentication)|string|
 |[ingress.kubernetes.io/base-url-scheme](#rewrite)|string|
 |[ingress.kubernetes.io/client-body-buffer-size](#client-body-buffer-size)|string|
 |[ingress.kubernetes.io/configuration-snippet](#configuration-snippet)|string|
@@ -148,6 +149,12 @@ ingress.kubernetes.io/auth-tls-verify-depth
 ```
 
 The validation depth between the provided client certificate and the Certification Authority chain.
+
+```
+ingress.kubernetes.io/auth-tls-error-page
+```
+
+The URL/Page that user should be redirected in case of a Certificate Authentication Error
 
 Please check the [tls-auth](/examples/auth/client-certs/nginx/README.md) example.
 

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -611,6 +611,9 @@ stream {
         ssl_client_certificate                  {{ $server.CertificateAuth.CAFileName }};
         ssl_verify_client                       on;
         ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
+        {{ if not (empty $server.CertificateAuth.ErrorPage)}}
+        error_page 495 496 = {{ $server.CertificateAuth.ErrorPage }};
+        {{ end }}
         {{ end }}
 
         {{ range $location := $server.Locations }}

--- a/core/pkg/ingress/annotations/authtls/main.go
+++ b/core/pkg/ingress/annotations/authtls/main.go
@@ -28,16 +28,18 @@ import (
 
 const (
 	// name of the secret
-	annotationAuthTLSSecret = "ingress.kubernetes.io/auth-tls-secret"
-	annotationAuthTLSDepth  = "ingress.kubernetes.io/auth-tls-verify-depth"
-	defaultAuthTLSDepth     = 1
+	annotationAuthTLSSecret    = "ingress.kubernetes.io/auth-tls-secret"
+	annotationAuthTLSDepth     = "ingress.kubernetes.io/auth-tls-verify-depth"
+	annotationAuthTLSErrorPage = "ingress.kubernetes.io/auth-tls-error-page"
+	defaultAuthTLSDepth        = 1
 )
 
 // AuthSSLConfig contains the AuthSSLCert used for muthual autentication
 // and the configured ValidationDepth
 type AuthSSLConfig struct {
 	resolver.AuthSSLCert
-	ValidationDepth int `json:"validationDepth"`
+	ValidationDepth int    `json:"validationDepth"`
+	ErrorPage       string `json:"errorPage"`
 }
 
 // Equal tests for equality between two AuthSSLConfig types
@@ -54,7 +56,9 @@ func (assl1 *AuthSSLConfig) Equal(assl2 *AuthSSLConfig) bool {
 	if assl1.ValidationDepth != assl2.ValidationDepth {
 		return false
 	}
-
+	if assl1.ErrorPage != assl2.ErrorPage {
+		return false
+	}
 	return true
 }
 
@@ -97,8 +101,14 @@ func (a authTLS) Parse(ing *extensions.Ingress) (interface{}, error) {
 		}
 	}
 
+	errorpage, err := parser.GetStringAnnotation(annotationAuthTLSErrorPage, ing)
+	if err != nil || errorpage == "" {
+		errorpage = ""
+	}
+
 	return &AuthSSLConfig{
 		AuthSSLCert:     *authCert,
 		ValidationDepth: tlsdepth,
+		ErrorPage:       errorpage,
 	}, nil
 }

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -37,6 +37,7 @@ Key:
 | `auth-realm` | Authentication realm. | | nginx, haproxy, trafficserver
 | `auth-tls-secret` | Name of secret for TLS client certification validation. | | nginx, haproxy
 | `auth-tls-verify-depth` | Maximum chain length of TLS client certificate. | | nginx
+| `auth-tls-error-page` | The page that user should be redirected in case of Auth error | | string
 | `auth-satisfy` | Behaviour when more than one of `auth-type`, `auth-tls-secret` or `whitelist-source-range` are configured: `all` or `any`. | `all` | trafficserver | `trafficserver`
 | `whitelist-source-range` | Comma-separate list of IP addresses to enable access to. | | nginx, haproxy, trafficserver
 

--- a/examples/auth/client-certs/nginx/README.md
+++ b/examples/auth/client-certs/nginx/README.md
@@ -32,7 +32,7 @@ Certificate Authentication is achieved through 2 annotations on the Ingress, as 
 | --- | --- | --- |
 |ingress.kubernetes.io/auth-tls-secret|Sets the secret that contains the authorized CA Chain|string|
 |ingress.kubernetes.io/auth-tls-verify-depth|The verification depth Certificate Authentication will make|number (default to 1)|
-
+|ingress.kubernetes.io/auth-tls-error-page|The page that user should be redirected in case of Auth error|string (default to empty|
 
 The following command instructs the controller to enable TLS authentication using the secret from the ``ingress.kubernetes.io/auth-tls-secret``
 annotation on the Ingress. Clients must present this cert to the loadbalancer, or they will receive a HTTP 400 response
@@ -61,6 +61,7 @@ Rules:
 Annotations:
   auth-tls-secret:	default/caingress
   auth-tls-verify-depth: 3
+  auth-tls-error-page: http://www.mysite.com/error-cert.html
 
 Events:
   FirstSeen	LastSeen	Count	From				SubObjectPath	Type		Reason	Message

--- a/examples/auth/client-certs/nginx/nginx-tls-auth.yaml
+++ b/examples/auth/client-certs/nginx/nginx-tls-auth.yaml
@@ -5,6 +5,7 @@ metadata:
     # Create this with kubectl create secret generic caingress --from-file=ca.crt --namespace=default
     ingress.kubernetes.io/auth-tls-secret: "default/caingress"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    auth-tls-error-page: "http://www.mysite.com/error-cert.html"
     kubernetes.io/ingress.class: "nginx"
   name: nginx-test
   namespace: default


### PR DESCRIPTION
This PR adds support for error handling in Client Certificate Authentication.

When user doesn't presents a valid certificate, he can be redirected to another page/URL instead of receiving a 400 error.

This must be a different location than the authenticated page, as an example:

- Host www.mysite.com redirects to HTTPs
- Host https://www.mysite.com requests a user certificate

If the used doesn't present a certificate, the redirect must be done to something like nocert.mysite.com, with a valid error page/location.



