### PR TITLE
fix README of nginx-ingress-controller

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -109,10 +109,9 @@ $ ./rootfs/nginx-ingress-controller --running-in-cluster=false --default-backend
 
 ## Deployment
 
-First create a default backend:
+First create a default backend and it's corresponding service:
 ```
 $ kubectl create -f examples/default-backend.yaml
-$ kubectl expose rc default-http-backend --port=80 --target-port=8080 --name=default-http-backend
 ```
 
 Loadbalancers are created via a ReplicationController or Daemonset:


### PR DESCRIPTION
I see `examples/default-backend.yaml` contains both a `Deployment` and a `Service`, then the next line

`kubectl expose rc ...`

seems to be needless. So fix it smoothly.