### PR TITLE
fix two doc issues in nginx/README

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -114,11 +114,9 @@ First create a default backend and it's corresponding service:
 $ kubectl create -f examples/default-backend.yaml
 ```
 
+Follow the [example-deployment](../../examples/deployment/nginx/README.md) steps to deploy nginx-ingress-controller in Kubernetes cluster (you may prefer other type of workloads, like Daemonset, in production environment).
 Loadbalancers are created via a ReplicationController or Daemonset:
 
-```
-$ kubectl create -f examples/rc-default.yaml
-```
 
 ## HTTP
 

--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -191,7 +191,7 @@ spec:
     serviceName: s1
     servicePort: 80
 ```
-Please follow [test.sh](https://github.com/bprashanth/Ingress/blob/master/examples/sni/nginx/test.sh) as a guide on how to generate secrets containing SSL certificates. The name of the secret can be different than the name of the certificate.
+Please follow [PREREQUISITES](../../examples/PREREQUISITES.md) as a guide on how to generate secrets containing SSL certificates. The name of the secret can be different than the name of the certificate.
 
 Check the [example](../../examples/tls-termination/nginx)
 


### PR DESCRIPTION
As discussed with @aledbf , these two doc issues are confirmed, and I'm fixing them smoothly.

Link to issue #1296 

Plus, there's another doc issue as described in [issue1296](https://github.com/kubernetes/ingress/issues/1296) (the 3rd one), we can't really tell differences with or without `default-ssl-certificate` according to those two `curl` output examples. They are the almost the same, should be fixed at spare time.