### PR TITLE
Fix kubeconfig example for nginx deployment

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -193,6 +193,9 @@ spec:
       containers:
       - name: default-http-backend
         image: gcr.io/google_containers/defaultbackend:1.0
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: kubeconfig
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Missing the `volumeMounts`, without it the pod will not start