### PR TITLE
Update sha256sum of nginx substitutions

### DIFF
--- a/images/nginx-slim/build.sh
+++ b/images/nginx-slim/build.sh
@@ -89,7 +89,7 @@ get_src 53e440737ed1aff1f09fae150219a45f16add0c8d6e84546cb7d80f73ebffd90 \
 get_src 9b1d0075df787338bb607f14925886249bda60b6b3156713923d5d59e99a708b \
         "https://github.com/atomx/nginx-http-auth-digest/archive/$NGINX_DIGEST_AUTH.tar.gz"
 
-get_src 8eabbcd5950fdcc718bb0ef9165206c2ed60f67cd9da553d7bc3e6fe4e338461 \
+get_src 618551948ab14cac51d6e4ad00452312c7b09938f59ebff4f93875013be31f2d \
         "https://github.com/yaoweibin/ngx_http_substitutions_filter_module/archive/$NGINX_SUBSTITUTIONS.tar.gz"
 
 


### PR DESCRIPTION
For whatever reason, this sha256sum changed. Double check this before merging, obviously, but it seems legit.