### PR TITLE
Release nginx-slim 0.25

### DIFF
--- a/images/nginx-slim/Makefile
+++ b/images/nginx-slim/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG = 0.24
+TAG = 0.25
 REGISTRY = gcr.io/google_containers
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le


### PR DESCRIPTION
This release adds support for opentracing (zipkin) and HTTP/2 headers compression