### PR TITLE
Add support for opentracing

### DIFF
--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -35,7 +35,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=gcr.io/google_containers/nginx-slim-$(ARCH):0.24
+BASEIMAGE?=gcr.io/google_containers/nginx-slim-$(ARCH):0.25
 
 ifeq ($(ARCH),arm)
     QEMUARCH=arm

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -369,6 +369,21 @@ type Configuration struct {
 	// Sets the header field for identifying the originating IP address of a client
 	// Default is X-Forwarded-For
 	ForwardedForHeader string `json:"forwarded-for-header,omitempty"`
+
+	// EnableOpentracing enables the nginx Opentracing extension
+	// https://github.com/rnburn/nginx-opentracing
+	// By default this is disabled
+	EnableOpentracing bool `json:"enable-opentracing"`
+
+	// ZipkinCollectorHost specifies the host to use when uploading traces
+	ZipkinCollectorHost string `json:"zipkin-collector-host"`
+
+	// ZipkinCollectorPort specifies the port to use when uploading traces
+	ZipkinCollectorPort int `json:"zipkin-collector-port"`
+
+	// ZipkinServiceName specifies the service name to use for any traces created
+	// Default: nginx
+	ZipkinServiceName string `json:"zipkin-service-name"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -448,6 +463,8 @@ func NewDefault() Configuration {
 		LimitConnZoneVariable:        defaultLimitConnZoneVariable,
 		BindAddressIpv4:              defBindAddress,
 		BindAddressIpv6:              defBindAddress,
+		ZipkinCollectorPort:          9411,
+		ZipkinServiceName:            "nginx",
 	}
 
 	if glog.V(5) {

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -87,6 +87,14 @@ http {
     underscores_in_headers          {{ if $cfg.EnableUnderscoresInHeaders }}on{{ else }}off{{ end }};
     ignore_invalid_headers          {{ if $cfg.IgnoreInvalidHeaders }}on{{ else }}off{{ end }};
 
+    {{ if (and $cfg.EnableOpentracing (ne $cfg.ZipkinCollectorHost "")) }}
+    opentracing on;
+
+    zipkin_collector_host           {{ $cfg.ZipkinCollectorHost }};
+    zipkin_collector_port           {{ $cfg.ZipkinCollectorPort }};
+    zipkin_service_name             {{ $cfg.ZipkinServiceName }};
+    {{ end }}
+
     include /etc/nginx/mime.types;
     default_type text/html;
     {{ if $cfg.UseGzip }}


### PR DESCRIPTION
fixes #1366

Test image: `quay.io/aledbf/nginx-ingress-controller:0.224`

Local zipkin:
`docker run -d -p 9411:9411 openzipkin/zipkin`

Configmap configuration:
```
apiVersion: v1
data:
  enable-opentracing: "true"
  zipkin-collector-host: 192.168.99.1
```

![screenshot from 2017-09-17 21 11 28](https://user-images.githubusercontent.com/161571/30526217-3a040b3a-9bed-11e7-87db-3e3da50d99a1.png)
