### PR TITLE
Add missing whitespace line between items

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -316,6 +316,7 @@ In NGINX this feature is implemented by the third party module [nginx-sticky-mod
 ### **Allowed parameters in configuration ConfigMap**
 
 **proxy-body-size:** Sets the maximum allowed size of the client request body. See NGINX [client_max_body_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size).
+
 **custom-http-errors:** Enables which HTTP codes should be passed for processing with the [error_page directive](http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page).
 Setting at least one code also enables [proxy_intercept_errors](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors) which are required to process error_page.
 


### PR DESCRIPTION
Add a whitespace line for improved readability.