### PR TITLE
Surpport snippet for server section by the annotation of the ingess

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -591,6 +591,10 @@ stream {
         {{ end }}
         {{ end }}
 
+        {{ if not (empty $server.ServerSnippet) }}
+        {{ $server.ServerSnippet }}
+        {{ end }}
+        
         {{ range $location := $server.Locations }}
         {{ $path := buildLocation $location }}
         {{ $authPath := buildAuthLocation $location }}

--- a/core/pkg/ingress/annotations/serversnippet/main.go
+++ b/core/pkg/ingress/annotations/serversnippet/main.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serversnippet
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+
+	"k8s.io/ingress/core/pkg/ingress/annotations/parser"
+)
+
+const (
+	annotation = "ingress.kubernetes.io/server-snippet"
+)
+
+type serverSnippet struct {
+}
+
+// NewParser creates a new CORS annotation parser
+func NewParser() parser.IngressAnnotation {
+	return serverSnippet{}
+}
+
+// Parse parses the annotations contained in the ingress rule
+// used to indicate if the location/s contains a fragment of
+// configuration to be included inside the paths of the rules
+func (a serverSnippet) Parse(ing *extensions.Ingress) (interface{}, error) {
+	return parser.GetStringAnnotation(annotation, ing)
+}

--- a/core/pkg/ingress/annotations/serversnippet/main.go
+++ b/core/pkg/ingress/annotations/serversnippet/main.go
@@ -29,7 +29,7 @@ const (
 type serverSnippet struct {
 }
 
-// NewParser creates a new CORS annotation parser
+// NewParser creates a new server snippet annotation parser
 func NewParser() parser.IngressAnnotation {
 	return serverSnippet{}
 }

--- a/core/pkg/ingress/annotations/serversnippet/main_test.go
+++ b/core/pkg/ingress/annotations/serversnippet/main_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serversnippet
+
+import (
+	"testing"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func TestParse(t *testing.T) {
+	ap := NewParser()
+	if ap == nil {
+		t.Fatalf("expected a parser.IngressAnnotation but returned nil")
+	}
+
+	testCases := []struct {
+		annotations map[string]string
+		expected    string
+	}{
+		{map[string]string{annotation: "more_headers"}, "more_headers"},
+		{map[string]string{annotation: "false"}, "false"},
+		{map[string]string{}, ""},
+		{nil, ""},
+	}
+
+	ing := &extensions.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: extensions.IngressSpec{},
+	}
+
+	for _, testCase := range testCases {
+		ing.SetAnnotations(testCase.annotations)
+		result, _ := ap.Parse(ing)
+		if result != testCase.expected {
+			t.Errorf("expected %v but returned %v, annotations: %s", testCase.expected, result, testCase.annotations)
+		}
+	}
+}

--- a/core/pkg/ingress/annotations/serversnippet/main_test.go
+++ b/core/pkg/ingress/annotations/serversnippet/main_test.go
@@ -19,9 +19,9 @@ package serversnippet
 import (
 	"testing"
 
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	api "k8s.io/client-go/pkg/api/v1"
-	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 func TestParse(t *testing.T) {

--- a/core/pkg/ingress/controller/annotations.go
+++ b/core/pkg/ingress/controller/annotations.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/annotations/redirect"
 	"k8s.io/ingress/core/pkg/ingress/annotations/rewrite"
 	"k8s.io/ingress/core/pkg/ingress/annotations/secureupstream"
+	"k8s.io/ingress/core/pkg/ingress/annotations/serversnippet"
 	"k8s.io/ingress/core/pkg/ingress/annotations/serviceupstream"
 	"k8s.io/ingress/core/pkg/ingress/annotations/sessionaffinity"
 	"k8s.io/ingress/core/pkg/ingress/annotations/snippet"
@@ -83,6 +84,7 @@ func newAnnotationExtractor(cfg extractorConfig) annotationExtractor {
 			"DefaultBackend":       defaultbackend.NewParser(cfg),
 			"UpstreamVhost":        upstreamvhost.NewParser(),
 			"VtsFilterKey":         vtsfilterkey.NewParser(),
+			"ServerSnippet":        serversnippet.NewParser(),
 		},
 	}
 }
@@ -128,6 +130,7 @@ const (
 	serverAlias          = "Alias"
 	clientBodyBufferSize = "ClientBodyBufferSize"
 	certificateAuth      = "CertificateAuth"
+	serverSnippet        = "ServerSnippet"
 )
 
 func (e *annotationExtractor) ServiceUpstream(ing *extensions.Ingress) bool {
@@ -180,4 +183,9 @@ func (e *annotationExtractor) CertificateAuth(ing *extensions.Ingress) *authtls.
 	}
 	secure := val.(*authtls.AuthSSLConfig)
 	return secure
+}
+
+func (e *annotationExtractor) ServerSnippet(ing *extensions.Ingress) string {
+	val, _ := e.annotations[serverSnippet].Parse(ing)
+	return val.(string)
 }

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -1065,6 +1065,28 @@ func (ic *GenericController) createServers(data []interface{},
 			servers[host].Alias = ""
 		}
 	}
+
+	// configure server snippet
+	for _, ingIf := range data {
+		ing := ingIf.(*extensions.Ingress)
+		if !class.IsValid(ing, ic.cfg.IngressClass, ic.cfg.DefaultIngressClass) {
+			continue
+		}
+
+		for _, rule := range ing.Spec.Rules {
+			host := rule.Host
+			if host == "" {
+				host = defServerName
+			}
+
+			srvsnippet := ic.annotations.ServerSnippet(ing)
+			// only add a server snippet if the server does not have one previously configured
+
+			if servers[host].ServerSnippet == "" && srvsnippet != "" {
+				servers[host].ServerSnippet = srvsnippet
+			}
+		}
+	}
 	return servers
 }
 

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -238,6 +238,7 @@ type Server struct {
 	CertificateAuth authtls.AuthSSLConfig `json:"certificateAuth"`
 
 	// ServerSnippet returns the snippet of server
+	// +optional
 	ServerSnippet string `json:"serverSnippet"`
 }
 

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -236,6 +236,9 @@ type Server struct {
 	// CertificateAuth indicates the this server requires mutual authentication
 	// +optional
 	CertificateAuth authtls.AuthSSLConfig `json:"certificateAuth"`
+
+	// ServerSnippet returns the snippet of server
+	ServerSnippet string `json:"serverSnippet"`
 }
 
 // Location describes an URI inside a server.


### PR DESCRIPTION
eg:
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
annotations:
ingress.kubernetes.io/server-snippet: |
set $agentflag 0;

if ($http_user_agent ~* "(Mobile)" )
{
set $agentflag 1;
}

  if ( $agentflag = 1 ) {
    return 301 https://m.example.com;
  }
```