### PR TITLE
Fix ConfigMap link in doc

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -1,6 +1,6 @@
 # Nginx Ingress Controller
 
-This is an nginx Ingress controller that uses [ConfigMap](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/configmap.md) to store the nginx configuration. See [Ingress controller documentation](../README.md) for details on how it works.
+This is an nginx Ingress controller that uses [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configmap/#understanding-configmaps) to store the nginx configuration. See [Ingress controller documentation](../README.md) for details on how it works.
 
 ## Contents
 * [Conventions](#conventions)


### PR DESCRIPTION
The link to the ConfigMap introduction is broken on the main Nginx README.

I propose to change it to the kubernetes.io task explaining what a ConfigMap is.