### PR TITLE
fix error when cert or key is nil

### DIFF
--- a/core/pkg/ingress/controller/backend_ssl.go
+++ b/core/pkg/ingress/controller/backend_ssl.go
@@ -85,6 +85,9 @@ func (ic *GenericController) getPemCertificate(secretName string) (*ingress.SSLC
 
 	var s *ingress.SSLCert
 	if okcert && okkey {
+		if cert == nil || key == nil {
+			return nil, fmt.Errorf("error retrieving cert or key from secret %v: %v", secretName, err)
+		}
 		s, err = ssl.AddOrUpdateCertAndKey(nsSecName, cert, key, ca)
 		if err != nil {
 			return nil, fmt.Errorf("unexpected error creating pem file %v", err)


### PR DESCRIPTION
If the key (`"tls.crt"`|`"tls.key"`) in secret.Data map exists, but the value is nil the ingress controller crashes. Check this and return an error if this is the case to prevent:
```
...
backend_ssl.go:64] adding secret <ns>/<sn> to the local store
runtime.go:66] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
```