### PR TITLE
Use nginx default value for SSLECDHCurve

### DIFF
--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -411,7 +411,7 @@ func NewDefault() Configuration {
 		ShowServerTokens:           true,
 		SSLBufferSize:              sslBufferSize,
 		SSLCiphers:                 sslCiphers,
-		SSLECDHCurve:               "secp384r1",
+		SSLECDHCurve:               "auto",
 		SSLProtocols:               sslProtocols,
 		SSLSessionCache:            true,
 		SSLSessionCacheSize:        sslSessionCacheSize,


### PR DESCRIPTION
This configuration setting permits nginx to auto discover supported curves based on what openssl was compiled with. With the old default of secp384r1 if you attempted to use a key from a different curve, for example prime256v1, the SSL handshake would fail in an awful way without any helpful errors logged anywhere.

The default setting in nginx has been "auto" since 1.11.0