### PR TITLE
Fix links after design proposals move

### DIFF
--- a/examples/daemonset/haproxy/README.md
+++ b/examples/daemonset/haproxy/README.md
@@ -1,6 +1,6 @@
 # Haproxy Ingress DaemonSet
 
-In some cases, the Ingress controller will be required to be run at all the nodes in cluster. Using [DaemonSet](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/daemon.md) can achieve this requirement.
+In some cases, the Ingress controller will be required to be run at all the nodes in cluster. Using [DaemonSet](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apps/daemon.md) can achieve this requirement.
 
 ## Prerequisites
 

--- a/examples/daemonset/nginx/README.md
+++ b/examples/daemonset/nginx/README.md
@@ -1,6 +1,6 @@
 # Nginx Ingress DaemonSet
 
-In some cases, the Ingress controller will be required to be run at all the nodes in cluster. Using [DaemonSet](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/daemon.md) can achieve this requirement.
+In some cases, the Ingress controller will be required to be run at all the nodes in cluster. Using [DaemonSet](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apps/daemon.md) can achieve this requirement.
 
 ## Default Backend
 


### PR DESCRIPTION
The design proposals were organized according to SIGs in https://github.com/kubernetes/community/pull/1010. This led to a couple of broken links.