### PR TITLE
Process queue items by time window

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -113,8 +113,6 @@ type GenericController struct {
 	runningConfig *ingress.Configuration
 
 	forceReload int32
-
-	initialSyncDone int32
 }
 
 // Configuration contains all the settings required by an Ingress controller
@@ -1224,8 +1222,6 @@ func (ic *GenericController) Start() {
 
 	createDefaultSSLCertificate()
 
-	ic.setInitialSyncDone()
-
 	go ic.syncQueue.Run(time.Second, ic.stopCh)
 
 	if ic.syncStatus != nil {
@@ -1249,14 +1245,6 @@ func (ic *GenericController) setForceReload(shouldReload bool) {
 	} else {
 		atomic.StoreInt32(&ic.forceReload, 0)
 	}
-}
-
-func (ic *GenericController) isInitialSyncDone() bool {
-	return atomic.LoadInt32(&ic.initialSyncDone) != 0
-}
-
-func (ic *GenericController) setInitialSyncDone() {
-	atomic.StoreInt32(&ic.initialSyncDone, 1)
 }
 
 func createDefaultSSLCertificate() {

--- a/core/pkg/ingress/controller/listers.go
+++ b/core/pkg/ingress/controller/listers.go
@@ -45,10 +45,7 @@ func (ic *GenericController) createListers(disableNodeLister bool) {
 				return
 			}
 			ic.recorder.Eventf(addIng, apiv1.EventTypeNormal, "CREATE", fmt.Sprintf("Ingress %s/%s", addIng.Namespace, addIng.Name))
-
-			if ic.isInitialSyncDone() {
-				ic.syncQueue.Enqueue(obj)
-			}
+			ic.syncQueue.Enqueue(obj)
 		},
 		DeleteFunc: func(obj interface{}) {
 			delIng, ok := obj.(*extensions.Ingress)

--- a/core/pkg/task/queue.go
+++ b/core/pkg/task/queue.go
@@ -31,8 +31,10 @@ var (
 	keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 )
 
-// Queue manages a work queue through an independent worker that
-// invokes the given sync function for every work item inserted.
+// Queue manages a time work queue through an independent worker that invokes the
+// given sync function for every work item inserted.
+// The queue uses an internal timestamp that allows the removal of certain elements
+// which timestamp is older than the last successful get operation.
 type Queue struct {
 	// queue is the work queue the worker polls
 	queue workqueue.RateLimitingInterface
@@ -42,6 +44,13 @@ type Queue struct {
 	workerDone chan bool
 
 	fn func(obj interface{}) (interface{}, error)
+
+	lastSync int64
+}
+
+type element struct {
+	Key       interface{}
+	Timestamp int64
 }
 
 // Run ...
@@ -56,13 +65,17 @@ func (t *Queue) Enqueue(obj interface{}) {
 		return
 	}
 
+	ts := time.Now().UnixNano()
 	glog.V(3).Infof("queuing item %v", obj)
 	key, err := t.fn(obj)
 	if err != nil {
 		glog.Errorf("%v", err)
 		return
 	}
-	t.queue.Add(key)
+	t.queue.Add(element{
+		Key:       key,
+		Timestamp: ts,
+	})
 }
 
 func (t *Queue) defaultKeyFunc(obj interface{}) (interface{}, error) {
@@ -84,13 +97,26 @@ func (t *Queue) worker() {
 			}
 			return
 		}
+		ts := time.Now().UnixNano()
 
-		glog.V(3).Infof("syncing %v", key)
+		item := key.(element)
+		if t.lastSync > item.Timestamp {
+			glog.V(3).Infof("skipping %v sync (%v > %v)", item.Key, t.lastSync, item.Timestamp)
+			t.queue.Forget(key)
+			t.queue.Done(key)
+			continue
+		}
+
+		glog.V(3).Infof("syncing %v", item.Key)
 		if err := t.sync(key); err != nil {
-			glog.Warningf("requeuing %v, err %v", key, err)
-			t.queue.AddRateLimited(key)
+			glog.Warningf("requeuing %v, err %v", item.Key, err)
+			t.queue.AddRateLimited(element{
+				Key:       item.Key,
+				Timestamp: time.Now().UnixNano(),
+			})
 		} else {
 			t.queue.Forget(key)
+			t.lastSync = ts
 		}
 
 		t.queue.Done(key)

--- a/core/pkg/task/queue_test.go
+++ b/core/pkg/task/queue_test.go
@@ -131,3 +131,29 @@ func TestEnqueueKeyError(t *testing.T) {
 	// shutdown queue before exit
 	q.Shutdown()
 }
+
+func TestSkipEnqueue(t *testing.T) {
+	// initialize result
+	atomic.StoreUint32(&sr, 0)
+	q := NewCustomTaskQueue(mockSynFn, mockKeyFn)
+	stopCh := make(chan struct{})
+	// run queue
+	go q.Run(time.Second, stopCh)
+	// mock object whichi will be enqueue
+	mo := mockEnqueueObj{
+		k: "testKey",
+		v: "testValue",
+	}
+	q.Enqueue(mo)
+	q.Enqueue(mo)
+	q.Enqueue(mo)
+	q.Enqueue(mo)
+	// wait for 'mockSynFn'
+	time.Sleep(time.Millisecond * 10)
+	if atomic.LoadUint32(&sr) != 1 {
+		t.Errorf("sr should be 1, but is %d", sr)
+	}
+
+	// shutdown queue before exit
+	q.Shutdown()
+}


### PR DESCRIPTION
This allows us to avoid building and compare a new Configuration (which is expensive) with the running configuration and cases where the sync is not required.


1. when inserting event to queue insert current timestamp with it (I will call it eventTimestamp)
2. just before taking any item from queue store current timestamp to a variable (I will call it takeoutTimestamp)
3. after taking item from queue complete all processing as usual. That will take some time but should leave the system synchronized at worst to the time of takeoutTimestamp
4. after synchronization is finished pop events from the queue as long as their eventTimestamp < takeoutTimestamp. That will get rid of all the events for changes that we are sure are already part of running state.

thanks to @Gregy for the logic ^^

fixes #1386
