### PR TITLE
Add support for proxy protocol decoding and encoding in TCP services

### DIFF
--- a/controllers/nginx/README.md
+++ b/controllers/nginx/README.md
@@ -334,8 +334,8 @@ version to fully support Kube-Lego is nginx Ingress controller 0.8.
 
 ## Exposing TCP services
 
-Ingress does not support TCP services (yet). For this reason this Ingress controller uses the flag `--tcp-services-configmap` to point to an existing config map where the key is the external port to use and the value is `<namespace/service name>:<service port>:[PROXY]`
-It is possible to use a number or the name of the port. The last field is optional. Adding `PROXY` in the last field we can enable Proxy Protocol in a TCP service.
+Ingress does not support TCP services (yet). For this reason this Ingress controller uses the flag `--tcp-services-configmap` to point to an existing config map where the key is the external port to use and the value is `<namespace/service name>:<service port>:[PROXY]:[PROXY]`
+It is possible to use a number or the name of the port. The two last fields are optional. Adding `PROXY` in either or both of the two last fields we can use Proxy Protocol decoding (listen) and/or encoding (proxy_pass) in a TCP service (https://www.nginx.com/resources/admin-guide/proxy-protocol/).
 
 The next example shows how to expose the service `example-go` running in the namespace `default` in the port `8080` using the port `9000`
 ```

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -434,19 +434,22 @@ stream {
     }
     server {
         {{ range $address := $all.Cfg.BindAddressIpv4 }}
-        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};
+        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
         {{ else }}
-        listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};
+        listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
         {{ end }}
         {{ if $IsIPV6Enabled }}
         {{ range $address := $all.Cfg.BindAddressIpv6 }}
-        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};
+        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
         {{ else }}
-        listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.UseProxyProtocol }} proxy_protocol{{ end }};
+        listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
         {{ end }}
         {{ end }}
         proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
         proxy_pass              tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
+        {{ if $tcpServer.Backend.ProxyProtocol.Encode }}
+        proxy_protocol          on;
+        {{ end }}
     }
 
     {{ end }}

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -359,5 +359,11 @@ type L4Backend struct {
 	Namespace string             `json:"namespace"`
 	Protocol  apiv1.Protocol     `json:"protocol"`
 	// +optional
-	UseProxyProtocol bool `json:"useProxyProtocol"`
+	ProxyProtocol ProxyProtocol `json:"proxyProtocol"`
+}
+
+// ProxyProtocol describes the proxy protocol configuration
+type ProxyProtocol struct {
+	Decode bool `json:"decode"`
+	Encode bool `json:"encode"`
 }


### PR DESCRIPTION
Examples:

```
apiVersion: v1
data:
  "9000": default/http-svc:80:PROXY:PROXY
kind: ConfigMap
metadata:
  name: ingress-controller-tcp
  namespace: kube-system

```

```
# TCP services
+    upstream tcp-default-http-svc-80 {
+        server                  172.17.0.3:8080;
+        server                  172.17.0.4:8080;
+    }
+
+    server {
+        listen                  9000 proxy_protocol;
+        listen                  [::]:9000 proxy_protocol;
+        proxy_pass        tcp-default-http-svc-80;
+        proxy_protocol   on;
+    }
```

```
apiVersion: v1
data:
  "9000": default/http-svc:80::PROXY
kind: ConfigMap
metadata:
  name: ingress-controller-tcp
  namespace: kube-system

```

```
 # TCP services
+    upstream tcp-default-http-svc-80 {
+        server                  172.17.0.3:8080;
+        server                  172.17.0.4:8080;
+    }
+
+    server {
+        listen                  9000;
+        listen                  [::]:9000;
+        proxy_pass        tcp-default-http-svc-80;
+        proxy_protocol   on;
+    }
```

```
apiVersion: v1
data:
  "9000": default/http-svc:80:PROXY
kind: ConfigMap
metadata:
  name: ingress-controller-tcp
  namespace: kube-system

```

```
# TCP services
+    upstream tcp-default-http-svc-80 {
+        server                  172.17.0.3:8080;
+        server                  172.17.0.4:8080;
+    }
+
+    server {
+        listen                  9000 proxy_protocol;
+        listen                  [::]:9000 proxy_protocol;
+        proxy_pass        tcp-default-http-svc-80;
+    }
```