### PR TITLE
Fix exec of readSecrets

### DIFF
--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -238,14 +238,14 @@ func (ic GenericController) GetService(name string) (*apiv1.Service, error) {
 // sync collects all the pieces required to assemble the configuration file and
 // then sends the content to the backend (OnUpdate) receiving the populated
 // template as response reloading the backend if is required.
-func (ic *GenericController) syncIngress(key interface{}) error {
+func (ic *GenericController) syncIngress(element interface{}) error {
 	ic.syncRateLimiter.Accept()
 
 	if ic.syncQueue.IsShuttingDown() {
 		return nil
 	}
 
-	if name, ok := key.(string); ok {
+	if name, ok := element.(task.Element).Key.(string); ok {
 		if obj, exists, _ := ic.listers.Ingress.GetByKey(name); exists {
 			ing := obj.(*extensions.Ingress)
 			ic.readSecrets(ing)

--- a/core/pkg/ingress/controller/controller.go
+++ b/core/pkg/ingress/controller/controller.go
@@ -238,17 +238,19 @@ func (ic GenericController) GetService(name string) (*apiv1.Service, error) {
 // sync collects all the pieces required to assemble the configuration file and
 // then sends the content to the backend (OnUpdate) receiving the populated
 // template as response reloading the backend if is required.
-func (ic *GenericController) syncIngress(element interface{}) error {
+func (ic *GenericController) syncIngress(item interface{}) error {
 	ic.syncRateLimiter.Accept()
 
 	if ic.syncQueue.IsShuttingDown() {
 		return nil
 	}
 
-	if name, ok := element.(task.Element).Key.(string); ok {
-		if obj, exists, _ := ic.listers.Ingress.GetByKey(name); exists {
-			ing := obj.(*extensions.Ingress)
-			ic.readSecrets(ing)
+	if element, ok := item.(task.Element); ok {
+		if name, ok := element.Key.(string); ok {
+			if obj, exists, _ := ic.listers.Ingress.GetByKey(name); exists {
+				ing := obj.(*extensions.Ingress)
+				ic.readSecrets(ing)
+			}
 		}
 	}
 

--- a/core/pkg/task/queue.go
+++ b/core/pkg/task/queue.go
@@ -48,7 +48,8 @@ type Queue struct {
 	lastSync int64
 }
 
-type element struct {
+// Element represents one item of the queue
+type Element struct {
 	Key       interface{}
 	Timestamp int64
 }
@@ -72,7 +73,7 @@ func (t *Queue) Enqueue(obj interface{}) {
 		glog.Errorf("%v", err)
 		return
 	}
-	t.queue.Add(element{
+	t.queue.Add(Element{
 		Key:       key,
 		Timestamp: ts,
 	})
@@ -99,7 +100,7 @@ func (t *Queue) worker() {
 		}
 		ts := time.Now().UnixNano()
 
-		item := key.(element)
+		item := key.(Element)
 		if t.lastSync > item.Timestamp {
 			glog.V(3).Infof("skipping %v sync (%v > %v)", item.Key, t.lastSync, item.Timestamp)
 			t.queue.Forget(key)
@@ -110,7 +111,7 @@ func (t *Queue) worker() {
 		glog.V(3).Infof("syncing %v", item.Key)
 		if err := t.sync(key); err != nil {
 			glog.Warningf("requeuing %v, err %v", item.Key, err)
-			t.queue.AddRateLimited(element{
+			t.queue.AddRateLimited(Element{
 				Key:       item.Key,
 				Timestamp: time.Now().UnixNano(),
 			})


### PR DESCRIPTION
Fixes the cast of `syncIngress(interface{})` param. Without this PR new secrets aren't added to the local store.