### PR TITLE
Fix haproxy example broken link

### DIFF
--- a/examples/deployment/haproxy/README.md
+++ b/examples/deployment/haproxy/README.md
@@ -1,6 +1,6 @@
 # Deploying HAProxy Ingress Controller
 
-If you don't have a Kubernetes cluster, please refer to [setup](/docs/dev/setup.md)
+If you don't have a Kubernetes cluster, please refer to [Setup cluster](/docs/dev/setup-cluster.md)
 for instructions on how to create a new one.
 
 ## Prerequisites


### PR DESCRIPTION
In the example of HAProxy deployment, we can see `step` reference link already broken, so I redirect it to `Setup cluster` page.