### PR TITLE
Expose UDP port in UDP ingress example

### DIFF
--- a/examples/udp/nginx/nginx-udp-ingress-controller.yaml
+++ b/examples/udp/nginx/nginx-udp-ingress-controller.yaml
@@ -47,6 +47,7 @@ spec:
           hostPort: 443
         - containerPort: 9001
           hostPort: 9001
+          protocol: UDP
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend


### PR DESCRIPTION
The port protocol in the nginx UDP loadbalancing example is not specified so it defaults to TCP.