### PR TITLE
[GCLB] Handle case of not having firewall create/update/delete with XPN

### DIFF
--- a/controllers/gce/controller/controller_test.go
+++ b/controllers/gce/controller/controller_test.go
@@ -53,7 +53,8 @@ func defaultBackendName(clusterName string) string {
 // newLoadBalancerController create a loadbalancer controller.
 func newLoadBalancerController(t *testing.T, cm *fakeClusterManager) *LoadBalancerController {
 	kubeClient := fake.NewSimpleClientset()
-	ctx := NewControllerContext(kubeClient, api_v1.NamespaceAll, 1*time.Second)
+	eventRecorder := utils.NewEventRecorder(kubeClient)
+	ctx := NewControllerContext(kubeClient, api_v1.NamespaceAll, 1*time.Second, eventRecorder)
 	lb, err := NewLoadBalancerController(kubeClient, ctx, cm.ClusterManager)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -95,10 +96,12 @@ func toIngressRules(hostRules map[string]utils.FakeIngressRuleValueMap) []extens
 
 // newIngress returns a new Ingress with the given path map.
 func newIngress(hostRules map[string]utils.FakeIngressRuleValueMap) *extensions.Ingress {
+	id := uuid.NewUUID()
 	return &extensions.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      fmt.Sprintf("%v", uuid.NewUUID()),
+			Name:      fmt.Sprintf("%v", id),
 			Namespace: api.NamespaceNone,
+			UID:       id,
 		},
 		Spec: extensions.IngressSpec{
 			Backend: &extensions.IngressBackend{

--- a/controllers/gce/controller/fakes.go
+++ b/controllers/gce/controller/fakes.go
@@ -17,7 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	compute "google.golang.org/api/compute/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -65,7 +68,7 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 		testDefaultBeNodePort,
 		namer,
 	)
-	frPool := firewalls.NewFirewallPool(firewalls.NewFakeFirewallsProvider(), namer)
+	frPool := firewalls.NewFirewallPool(firewalls.NewFakeFirewallsProvider(false, false), namer, fakeRaiseIngressEvent)
 	cm := &ClusterManager{
 		ClusterNamer: namer,
 		instancePool: nodePool,
@@ -74,4 +77,13 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 		firewallPool: frPool,
 	}
 	return &fakeClusterManager{cm, fakeLbs, fakeBackends, fakeIGs}
+}
+
+func fakeRaiseIngressEvent(ing *extensions.Ingress, reason, msg string) {
+	ingName := "nil-ingress"
+	if ing != nil {
+		ingName = ing.Name
+	}
+
+	fmt.Printf("Ingress %q Event %q: %q\n", ingName, reason, msg)
 }

--- a/controllers/gce/firewalls/fakes.go
+++ b/controllers/gce/firewalls/fakes.go
@@ -25,14 +25,21 @@ import (
 )
 
 type fakeFirewallsProvider struct {
-	fw         map[string]*compute.Firewall
-	networkUrl string
+	fw               map[string]*compute.Firewall
+	networkProjectID string
+	networkURL       string
+	onXPN            bool
+	fwReadOnly       bool
 }
 
 // NewFakeFirewallsProvider creates a fake for firewall rules.
-func NewFakeFirewallsProvider() *fakeFirewallsProvider {
+func NewFakeFirewallsProvider(onXPN bool, fwReadOnly bool) *fakeFirewallsProvider {
 	return &fakeFirewallsProvider{
-		fw: make(map[string]*compute.Firewall),
+		fw:               make(map[string]*compute.Firewall),
+		networkProjectID: "test-network-project",
+		networkURL:       "/path/to/my-network",
+		onXPN:            onXPN,
+		fwReadOnly:       fwReadOnly,
 	}
 }
 
@@ -44,7 +51,7 @@ func (ff *fakeFirewallsProvider) GetFirewall(name string) (*compute.Firewall, er
 	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
-func (ff *fakeFirewallsProvider) CreateFirewall(f *compute.Firewall) error {
+func (ff *fakeFirewallsProvider) doCreateFirewall(f *compute.Firewall) error {
 	if _, exists := ff.fw[f.Name]; exists {
 		return fmt.Errorf("firewall rule %v already exists", f.Name)
 	}
@@ -52,7 +59,15 @@ func (ff *fakeFirewallsProvider) CreateFirewall(f *compute.Firewall) error {
 	return nil
 }
 
-func (ff *fakeFirewallsProvider) DeleteFirewall(name string) error {
+func (ff *fakeFirewallsProvider) CreateFirewall(f *compute.Firewall) error {
+	if ff.fwReadOnly {
+		return utils.FakeGoogleAPIForbiddenErr()
+	}
+
+	return ff.doCreateFirewall(f)
+}
+
+func (ff *fakeFirewallsProvider) doDeleteFirewall(name string) error {
 	// We need the full name for the same reason as CreateFirewall.
 	_, exists := ff.fw[name]
 	if !exists {
@@ -63,7 +78,15 @@ func (ff *fakeFirewallsProvider) DeleteFirewall(name string) error {
 	return nil
 }
 
-func (ff *fakeFirewallsProvider) UpdateFirewall(f *compute.Firewall) error {
+func (ff *fakeFirewallsProvider) DeleteFirewall(name string) error {
+	if ff.fwReadOnly {
+		return utils.FakeGoogleAPIForbiddenErr()
+	}
+
+	return ff.doDeleteFirewall(name)
+}
+
+func (ff *fakeFirewallsProvider) doUpdateFirewall(f *compute.Firewall) error {
 	// We need the full name for the same reason as CreateFirewall.
 	_, exists := ff.fw[f.Name]
 	if !exists {
@@ -74,8 +97,24 @@ func (ff *fakeFirewallsProvider) UpdateFirewall(f *compute.Firewall) error {
 	return nil
 }
 
+func (ff *fakeFirewallsProvider) UpdateFirewall(f *compute.Firewall) error {
+	if ff.fwReadOnly {
+		return utils.FakeGoogleAPIForbiddenErr()
+	}
+
+	return ff.doUpdateFirewall(f)
+}
+
+func (ff *fakeFirewallsProvider) NetworkProjectID() string {
+	return ff.networkProjectID
+}
+
 func (ff *fakeFirewallsProvider) NetworkURL() string {
-	return ff.networkUrl
+	return ff.networkURL
+}
+
+func (ff *fakeFirewallsProvider) OnXPN() bool {
+	return ff.onXPN
 }
 
 func (ff *fakeFirewallsProvider) GetNodeTags(nodeNames []string) ([]string, error) {

--- a/controllers/gce/firewalls/interfaces.go
+++ b/controllers/gce/firewalls/interfaces.go
@@ -18,12 +18,13 @@ package firewalls
 
 import (
 	compute "google.golang.org/api/compute/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 )
 
 // SingleFirewallPool syncs the firewall rule for L7 traffic.
 type SingleFirewallPool interface {
 	// TODO: Take a list of node ports for the firewall.
-	Sync(nodePorts []int64, nodeNames []string) error
+	Sync(nodePorts []int64, nodeNames []string, ing *extensions.Ingress) error
 	Shutdown() error
 }
 
@@ -36,5 +37,7 @@ type Firewall interface {
 	DeleteFirewall(name string) error
 	UpdateFirewall(f *compute.Firewall) error
 	GetNodeTags(nodeNames []string) ([]string, error)
+	NetworkProjectID() string
 	NetworkURL() string
+	OnXPN() bool
 }


### PR DESCRIPTION
If the controller does not have the ability of managing the firewall rule on XPN, the controller will instead raise an event. The event message prints out the resulting gcloud command.

Since this bug (https://github.com/kubernetes/ingress/issues/950) is still relevant, events raised here will apply to all ingresses that have synced. For example, suppose you have two ingress objects. Ingress-A references nodeport-A and ingress-B references nodeport-B. Assuming a firewall rule exists with only nodeport-A, an event will be raised on both ingresses (after syncing for each ingress).