### PR TITLE
GCE: Updating instance groups interface to accept all named ports at once

### DIFF
--- a/controllers/gce/backends/backends_test.go
+++ b/controllers/gce/backends/backends_test.go
@@ -80,7 +80,7 @@ func TestBackendPoolAdd(t *testing.T) {
 			// Add a backend for a port, then re-add the same port and
 			// make sure it corrects a broken link from the backend to
 			// the instance group.
-			err := pool.Add(nodePort, nil)
+			err := pool.Ensure([]ServicePort{nodePort}, nil)
 			if err != nil {
 				t.Fatalf("Did not find expect error when adding a nodeport: %v, err: %v", nodePort, err)
 			}
@@ -95,10 +95,11 @@ func TestBackendPoolAdd(t *testing.T) {
 				t.Fatalf("Backend %v has wrong port %v, expected %v", be.Name, be.Port, nodePort)
 			}
 
-			// Check that the instance group has the new port
+			// Check that the instance group has the new port.
+			ig, err := fakeIGs.GetInstanceGroup(namer.IGName(), defaultZone)
 			var found bool
-			for _, port := range fakeIGs.Ports {
-				if port == nodePort.Port {
+			for _, port := range ig.NamedPorts {
+				if port.Port == nodePort.Port {
 					found = true
 				}
 			}
@@ -143,7 +144,7 @@ func TestHealthCheckMigration(t *testing.T) {
 	hcp.CreateHttpHealthCheck(legacyHC)
 
 	// Add the service port to the backend pool
-	pool.Add(p, nil)
+	pool.Ensure([]ServicePort{p}, nil)
 
 	// Assert the proper health check was created
 	hc, _ := pool.healthChecker.Get(p.Port)
@@ -168,7 +169,7 @@ func TestBackendPoolUpdate(t *testing.T) {
 	namer := utils.Namer{}
 
 	p := ServicePort{Port: 3000, Protocol: utils.ProtocolHTTP}
-	pool.Add(p, nil)
+	pool.Ensure([]ServicePort{p}, nil)
 	beName := namer.BeName(p.Port)
 
 	be, err := f.GetGlobalBackendService(beName)
@@ -188,7 +189,7 @@ func TestBackendPoolUpdate(t *testing.T) {
 
 	// Update service port to encrypted
 	p.Protocol = utils.ProtocolHTTPS
-	pool.Sync([]ServicePort{p}, nil)
+	pool.Ensure([]ServicePort{p}, nil)
 
 	be, err = f.GetGlobalBackendService(beName)
 	if err != nil {
@@ -214,7 +215,7 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	namer := utils.Namer{}
 
 	nodePort := ServicePort{Port: 8080, Protocol: utils.ProtocolHTTP}
-	pool.Add(nodePort, nil)
+	pool.Ensure([]ServicePort{nodePort}, nil)
 	beName := namer.BeName(nodePort.Port)
 
 	be, _ := f.GetGlobalBackendService(beName)
@@ -227,7 +228,7 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	f.calls = []int{}
 	f.UpdateGlobalBackendService(be)
 
-	pool.Add(nodePort, nil)
+	pool.Ensure([]ServicePort{nodePort}, nil)
 	for _, call := range f.calls {
 		if call == utils.Create {
 			t.Fatalf("Unexpected create for existing backend service")
@@ -260,10 +261,10 @@ func TestBackendPoolSync(t *testing.T) {
 	f := NewFakeBackendServices(noOpErrFunc)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString())
 	pool, _ := newTestJig(f, fakeIGs, true)
-	pool.Add(ServicePort{Port: 81}, nil)
-	pool.Add(ServicePort{Port: 90}, nil)
-	if err := pool.Sync(svcNodePorts, nil); err != nil {
-		t.Errorf("Expected backend pool to sync, err: %v", err)
+	pool.Ensure([]ServicePort{ServicePort{Port: 81}}, nil)
+	pool.Ensure([]ServicePort{ServicePort{Port: 90}}, nil)
+	if err := pool.Ensure(svcNodePorts, nil); err != nil {
+		t.Errorf("Expected backend pool to add node ports, err: %v", err)
 	}
 	if err := pool.GC(svcNodePorts); err != nil {
 		t.Errorf("Expected backend pool to GC, err: %v", err)
@@ -361,7 +362,7 @@ func TestBackendPoolDeleteLegacyHealthChecks(t *testing.T) {
 	})
 
 	// Have pool sync the above backend service
-	bp.Add(ServicePort{Port: 80, Protocol: utils.ProtocolHTTPS}, nil)
+	bp.Ensure([]ServicePort{ServicePort{Port: 80, Protocol: utils.ProtocolHTTPS}}, nil)
 
 	// Verify the legacy health check has been deleted
 	_, err = hcp.GetHttpHealthCheck(beName)
@@ -388,7 +389,7 @@ func TestBackendPoolShutdown(t *testing.T) {
 	namer := utils.Namer{}
 
 	// Add a backend-service and verify that it doesn't exist after Shutdown()
-	pool.Add(ServicePort{Port: 80}, nil)
+	pool.Ensure([]ServicePort{ServicePort{Port: 80}}, nil)
 	pool.Shutdown()
 	if _, err := f.GetGlobalBackendService(namer.BeName(80)); err == nil {
 		t.Fatalf("%v", err)
@@ -402,7 +403,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	namer := utils.Namer{}
 
 	// This will add the instance group k8s-ig to the instance pool
-	pool.Add(ServicePort{Port: 80}, nil)
+	pool.Ensure([]ServicePort{ServicePort{Port: 80}}, nil)
 
 	be, err := f.GetGlobalBackendService(namer.BeName(80))
 	if err != nil {
@@ -420,7 +421,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	}
 
 	// Make sure repeated adds don't clobber the inserted instance group
-	pool.Add(ServicePort{Port: 80}, nil)
+	pool.Ensure([]ServicePort{ServicePort{Port: 80}}, nil)
 	be, err = f.GetGlobalBackendService(namer.BeName(80))
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -462,7 +463,7 @@ func TestBackendCreateBalancingMode(t *testing.T) {
 			return nil
 		}
 
-		pool.Add(nodePort, nil)
+		pool.Ensure([]ServicePort{nodePort}, nil)
 		be, err := f.GetGlobalBackendService(namer.BeName(nodePort.Port))
 		if err != nil {
 			t.Fatalf("%v", err)

--- a/controllers/gce/backends/interfaces.go
+++ b/controllers/gce/backends/interfaces.go
@@ -30,10 +30,9 @@ type probeProvider interface {
 // as gce backendServices, and sync them through the BackendServices interface.
 type BackendPool interface {
 	Init(p probeProvider)
-	Add(port ServicePort, igs []*compute.InstanceGroup) error
+	Ensure(ports []ServicePort, igs []*compute.InstanceGroup) error
 	Get(port int64) (*compute.BackendService, error)
 	Delete(port int64) error
-	Sync(ports []ServicePort, igs []*compute.InstanceGroup) error
 	GC(ports []ServicePort) error
 	Shutdown() error
 	Status(name string) string

--- a/controllers/gce/controller/utils_test.go
+++ b/controllers/gce/controller/utils_test.go
@@ -71,16 +71,11 @@ func TestInstancesAddedToZones(t *testing.T) {
 
 	// Create 2 igs, one per zone.
 	testIG := "test-ig"
-	testPort := int64(3001)
-	lbc.CloudClusterManager.instancePool.AddInstanceGroup(testIG, testPort)
+	lbc.CloudClusterManager.instancePool.AddInstanceGroup(testIG, []int64{int64(3001)})
 
 	// node pool syncs kube-nodes, this will add them to both igs.
 	lbc.CloudClusterManager.instancePool.Sync([]string{"n1", "n2", "n3"})
 	gotZonesToNode := cm.fakeIGs.GetInstancesByZone()
-
-	if cm.fakeIGs.Ports[0] != testPort {
-		t.Errorf("Expected the same node port on all igs, got ports %+v", cm.fakeIGs.Ports)
-	}
 
 	for z, nodeNames := range zoneToNode {
 		if ig, err := cm.fakeIGs.GetInstanceGroup(testIG, z); err != nil {

--- a/controllers/gce/instances/fakes.go
+++ b/controllers/gce/instances/fakes.go
@@ -60,7 +60,6 @@ func (z *FakeZoneLister) GetZoneForNode(name string) (string, error) {
 type FakeInstanceGroups struct {
 	instances        sets.String
 	instanceGroups   []*compute.InstanceGroup
-	Ports            []int64
 	getResult        *compute.InstanceGroup
 	listResult       *compute.InstanceGroupsListInstances
 	calls            []int
@@ -150,21 +149,18 @@ func (f *FakeInstanceGroups) RemoveInstancesFromInstanceGroup(name, zone string,
 }
 
 func (f *FakeInstanceGroups) SetNamedPortsOfInstanceGroup(igName, zone string, namedPorts []*compute.NamedPort) error {
-	found := false
-	for _, ig := range f.instanceGroups {
-		if ig.Name == igName && ig.Zone == zone {
-			found = true
+	var ig *compute.InstanceGroup
+	for _, igp := range f.instanceGroups {
+		if igp.Name == igName && igp.Zone == zone {
+			ig = igp
 			break
 		}
 	}
-	if !found {
+	if ig == nil {
 		return fmt.Errorf("Failed to find instance group %q in zone %q", igName, zone)
 	}
 
-	f.Ports = f.Ports[:0]
-	for _, port := range namedPorts {
-		f.Ports = append(f.Ports, port.Port)
-	}
+	ig.NamedPorts = namedPorts
 	return nil
 }
 

--- a/controllers/gce/instances/interfaces.go
+++ b/controllers/gce/instances/interfaces.go
@@ -32,7 +32,7 @@ type NodePool interface {
 	Init(zl zoneLister)
 
 	// The following 2 methods operate on instance groups.
-	AddInstanceGroup(name string, port int64) ([]*compute.InstanceGroup, *compute.NamedPort, error)
+	AddInstanceGroup(name string, ports []int64) ([]*compute.InstanceGroup, []*compute.NamedPort, error)
 	DeleteInstanceGroup(name string) error
 
 	// TODO: Refactor for modularity

--- a/controllers/gce/instances/utils.go
+++ b/controllers/gce/instances/utils.go
@@ -8,6 +8,6 @@ import (
 
 // Helper method to create instance groups.
 // This method exists to ensure that we are using the same logic at all places.
-func EnsureInstanceGroupsAndPorts(nodePool NodePool, namer *utils.Namer, port int64) ([]*compute.InstanceGroup, *compute.NamedPort, error) {
-	return nodePool.AddInstanceGroup(namer.IGName(), port)
+func EnsureInstanceGroupsAndPorts(nodePool NodePool, namer *utils.Namer, ports []int64) ([]*compute.InstanceGroup, []*compute.NamedPort, error) {
+	return nodePool.AddInstanceGroup(namer.IGName(), ports)
 }

--- a/controllers/gce/loadbalancers/loadbalancers.go
+++ b/controllers/gce/loadbalancers/loadbalancers.go
@@ -169,7 +169,7 @@ func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
 		// Lazily create a default backend so we don't tax users who don't care
 		// about Ingress by consuming 1 of their 3 GCE BackendServices. This
 		// BackendService is GC'd when there are no more Ingresses.
-		if err := l.defaultBackendPool.Add(l.defaultBackendNodePort, nil); err != nil {
+		if err := l.defaultBackendPool.Ensure([]backends.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
 			return err
 		}
 		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.Port)


### PR DESCRIPTION
Follow up from https://github.com/kubernetes/ingress/pull/1033.

Updating the BackendPool (for backend services) and NodePool (for instance groups) interfaces so that all named ports can be added to an instance group at once. This removes unnecessary API calls where for each named port, we were first fetching the instance group and then setting the named port on it. With this change, we should fetch the instance group once and then set all named ports in a single API call.

Have also removed BackendPool.Sync method since Add does the same now.
Sync was also misleading since it only added backend services and didnt delete them. Add is more explicit.

cc @nicksardo @csbell @G-Harmon