### PR TITLE
Add original $host header on the auth request

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -528,6 +528,7 @@ stream {
             proxy_set_header       X-Code             {{ $errCode }};
             proxy_set_header       X-Format           $http_accept;
             proxy_set_header       X-Original-URI     $request_uri;
+            proxy_set_header       X-Original-Host    $http_host;
             proxy_set_header       X-Namespace        $namespace;
             proxy_set_header       X-Ingress-Name     $ingress_name;
             proxy_set_header       X-Service-Name     $service_name;


### PR DESCRIPTION
It would be quite useful to send the original $host header information to the internal /auth request nginx does.

For example, when the application sits on a different (sub-)domain than the auth service.
This way it can use it to do its job!

Thanks!


Reference: https://github.com/kubernetes/ingress/commit/8fc6101d3ba11a1117d211bdac6104dab7af8eeb

cc @aledbf

