### PR TITLE
Add the original URL to the auth request

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -668,6 +668,7 @@ stream {
             {{ end }}
             proxy_pass_request_headers  on;
             proxy_set_header            Host {{ $location.ExternalAuth.Host }};
+            proxy_set_header            X-Original-URL $scheme://$http_host$request_uri;
             proxy_ssl_server_name       on;
 
             client_max_body_size        "{{ $location.Proxy.BodySize }}";


### PR DESCRIPTION
It would be nice to send the original URL to the auth request.

This would be useful in cases where the /auth request is on a different domain as the service thats behind it.

Thanks!