### PR TITLE
Typo: Add missing {{ }}

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -720,7 +720,7 @@ stream {
             {{ end }}
 
             {{ if not (empty $location.ExternalAuth.SigninURL) }}
-            error_page 401 = $location.ExternalAuth.SigninURL;
+            error_page 401 = {{ $location.ExternalAuth.SigninURL }};
             {{ end }}
 
             {{/* if the location contains a rate limit annotation, create one */}}


### PR DESCRIPTION
Nginx ingress does not seems to be working because of this ;)

reference: https://github.com/kubernetes/ingress/commit/8fc6101d3ba11a1117d211bdac6104dab7af8eeb