### PR TITLE
configurable ssl_verify_client

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -47,6 +47,7 @@ The following annotations are supported:
 |[ingress.kubernetes.io/auth-url](#external-authentication)|string|
 |[ingress.kubernetes.io/auth-tls-secret](#certificate-authentication)|string|
 |[ingress.kubernetes.io/auth-tls-verify-depth](#certificate-authentication)|number|
+|[ingress.kubernetes.io/auth-tls-verify-client](#certificate-authentication)|string|
 |[ingress.kubernetes.io/auth-tls-error-page](#certificate-authentication)|string|
 |[ingress.kubernetes.io/base-url-scheme](#rewrite)|string|
 |[ingress.kubernetes.io/client-body-buffer-size](#client-body-buffer-size)|string|
@@ -154,6 +155,12 @@ ingress.kubernetes.io/auth-tls-verify-depth
 ```
 
 The validation depth between the provided client certificate and the Certification Authority chain.
+
+```
+ingress.kubernetes.io/auth-tls-verify-client
+```
+
+Enables verification of client certificates.
 
 ```
 ingress.kubernetes.io/auth-tls-error-page

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -636,7 +636,7 @@ stream {
         {{ if not (empty $server.CertificateAuth.CAFileName) }}
         # PEM sha: {{ $server.CertificateAuth.PemSHA }}
         ssl_client_certificate                  {{ $server.CertificateAuth.CAFileName }};
-        ssl_verify_client                       on;
+        ssl_verify_client                       {{ $server.CertificateAuth.VerifyClient }};
         ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
         {{ if not (empty $server.CertificateAuth.ErrorPage)}}
         error_page 495 496 = {{ $server.CertificateAuth.ErrorPage }};

--- a/examples/auth/client-certs/nginx/README.md
+++ b/examples/auth/client-certs/nginx/README.md
@@ -31,6 +31,7 @@ Certificate Authentication is achieved through 2 annotations on the Ingress, as 
 | --- | --- | --- |
 |ingress.kubernetes.io/auth-tls-secret|Sets the secret that contains the authorized CA Chain|string|
 |ingress.kubernetes.io/auth-tls-verify-depth|The verification depth Certificate Authentication will make|number (default to 1)|
+|ingress.kubernetes.io/auth-tls-verify-client|Enables verification of client certificates|string (default to on)|
 |ingress.kubernetes.io/auth-tls-error-page|The page that user should be redirected in case of Auth error|string (default to empty|
 
 The following command instructs the controller to enable TLS authentication using the secret from the ``ingress.kubernetes.io/auth-tls-secret``

--- a/examples/auth/client-certs/nginx/nginx-tls-auth.yaml
+++ b/examples/auth/client-certs/nginx/nginx-tls-auth.yaml
@@ -5,6 +5,7 @@ metadata:
     # Create this with kubectl create secret generic caingress --from-file=ca.crt --namespace=default
     ingress.kubernetes.io/auth-tls-secret: "default/caingress"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    ingress.kubernetes.io/auth-tls-verify-client: "on"
     auth-tls-error-page: "http://www.mysite.com/error-cert.html"
     kubernetes.io/ingress.class: "nginx"
   name: nginx-test


### PR DESCRIPTION
Allows configuration of [ssl_verify_client](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_verify_client) via annotation. Fixes #1359.
